### PR TITLE
added opik tracer and fix orchestrator prompt

### DIFF
--- a/CoScientist/agents/agents.py
+++ b/CoScientist/agents/agents.py
@@ -13,6 +13,11 @@ from CoScientist.config import get_settings
 from CoScientist.agents.prompts import hypotheses_instruction, research_instruction, fedot_instruction, orchestrator_instruction, tool_retriever_instruction
 from CoScientist.tools import fedot_toolset_instance, websearch_toolset_instance, retrieval_toolset_instance
 from CoScientist.storage import RetrievalFinalResult
+from CoScientist.logging import multi_agent_tracer
+
+
+from opik.integrations.adk import track_adk_agent_recursive
+
 
 from typing import Dict, Any
 import uuid
@@ -86,6 +91,8 @@ orchestrator_agent = LlmAgent(
     description="Main Orchestrator Agent",
     tools=[AgentTool(agent=hypotheses_agent), AgentTool(agent=research_agent), AgentTool(agent=task_execution_agent)],
 )
+
+track_adk_agent_recursive(orchestrator_agent, multi_agent_tracer)
 
 
 

--- a/CoScientist/agents/prompts.py
+++ b/CoScientist/agents/prompts.py
@@ -85,12 +85,25 @@ Available tools from agents:
 
 1. Understand the task. 
 2. Plan minimal steps to solve it.
-3. Delegate:
-    * Use Hypothesis → when direction is unclear
-    * Use Research → for mining knowledge
-    * Use Experiment → to test/validate ideas and calculations
-4. Iterate if needed, combining results.
-5. Be efficient: avoid unnecessary steps.
+3. Delegate strategically with the following priority:
 
+    - Experiment Agent (HIGH PRIORITY) – use first whenever the task involves:
+    * calculations
+    * simulations
+    * data processing
+    * model inference
+    * property estimation
+    → Prefer this over Research whenever a result can be computed instead of looked up
+    - Research Agent (LOWER PRIORITY) – use only when:
+    * external knowledge is strictly required
+    * the problem cannot be solved computationally
+    * validation against literature is necessary
+    - Hypothesis Agent – use when:
+    * the direction is unclear
+    * multiple approaches need to be proposed
+5. Avoid unnecessary Research calls if the Experiment Agent can produce the answer.
+6. Iterate efficiently, combining agents only when needed.
+7. Be computation-first, not search-first.
 You coordinate — do not solve everything yourself.
+
 '''

--- a/CoScientist/config/settings.py
+++ b/CoScientist/config/settings.py
@@ -113,7 +113,7 @@ class S3Settings(BaseModel):
 class OpikSettings(BaseModel):
     api_key: Optional[str] = None
     url_override: Optional[str] = None
-    project_name: Optional[str] = None
+    opik_project_name: Optional[str] = None
 
 
 # =========================

--- a/CoScientist/logging/__init__.py
+++ b/CoScientist/logging/__init__.py
@@ -1,4 +1,6 @@
 """Logging module."""
 from CoScientist.logging.logger import get_logger
+from CoScientist.logging.opik_tracer import multi_agent_tracer
 
-__all__ = ["get_logger"]
+__all__ = ["get_logger", 
+            "multi_agent_tracer"]

--- a/CoScientist/logging/logger.py
+++ b/CoScientist/logging/logger.py
@@ -12,16 +12,19 @@ formatter = logging.Formatter(
     "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 )
 
+
+os.makedirs(settings.storage.logging_path, exist_ok=True)
+
 # File handler
 file_handler = logging.FileHandler(os.path.join(settings.storage.logging_path, "app.log"))
 file_handler.setFormatter(formatter)
 
 # Console handler
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(formatter)
+# console_handler = logging.StreamHandler()
+# console_handler.setFormatter(formatter)
 
 logger.addHandler(file_handler)
-logger.addHandler(console_handler)
+# logger.addHandler(console_handler)
 
 
 def get_logger():

--- a/CoScientist/logging/opik_tracer.py
+++ b/CoScientist/logging/opik_tracer.py
@@ -1,0 +1,16 @@
+from CoScientist.config import get_settings
+import os
+
+settings = get_settings()
+os.environ['OPIK_API_KEY'] = settings.opik.api_key
+
+import opik
+opik.configure(use_local=False)
+
+from opik.integrations.adk import OpikTracer
+
+multi_agent_tracer = OpikTracer(
+    name="multi-agent-orchestrator",
+    metadata=settings.model_dump(),
+    project_name="adk-coscientist"
+)


### PR DESCRIPTION
in this pr (fixes #179):
1. Opik tracer is introduced. All logs can be seen at [official website](https://www.comet.com/opik/itmo-nss/projects/019d6292-e53d-70c2-b41f-4a2a5005d8bd/). For credentials and API key please dm me.
2. IMPORTANT: make sure there is no /root/.opik.config file on before first start
3. Also fixed prompt for the orchestrator agent. Current prompt focuses on computation-first research-second logic rather than research-first pipeline