### PR TITLE
Feat/pipeline robustness and tool discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+*.env
 # C extensions
 *.so
 .vscode
@@ -25,7 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
+/model_bench
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -195,3 +195,17 @@ workspace/
 graph_runs/
 openhands.log
 task_tracker_data.json
+
+# Experiment run logs & history (generated artifacts; keep harness + COMPARISON*.md)
+model_bench/out/
+model_bench/out_*/
+*.events.jsonl
+*.summary.json
+analysis.json
+# experiment result dumps / trace manifests (e.g. scripts/experiments, scripts/opik_eval)
+**/experiments/results/
+**/opik_eval/results/
+trace_manifest.jsonl
+
+# Auxiliary test scaffolding for ported features (not architecture)
+CoScientist/tests/unit/test_llm_repair.py

--- a/CoScientist/agents/__init__.py
+++ b/CoScientist/agents/__init__.py
@@ -7,7 +7,13 @@ existing imports keep working.
 """
 from CoScientist.assembly import build_system
 from CoScientist.logging import multi_agent_tracer
+from CoScientist.agents.llm_repair import install_json_repair
 from opik.integrations.adk import track_adk_agent_recursive
+
+# Guard the LiteLlm tool-call JSON boundary process-wide BEFORE any runner executes:
+# a malformed tool-call payload (qwen truncation / missing comma) must not kill the run.
+# Idempotent; installed once at first import of the agents package (CLI + web both hit this).
+install_json_repair()
 
 _system = build_system()
 

--- a/CoScientist/agents/llm_repair.py
+++ b/CoScientist/agents/llm_repair.py
@@ -1,0 +1,84 @@
+"""JSON-repair shim for the LiteLlm tool-call boundary (F015a.A4 failure #1).
+
+qwen sometimes emits malformed JSON in `tool_call.function.arguments` (truncation /
+missing comma / extra data — worse for big payloads like a `submit_plan` plan). ADK
+parses it in `google.adk.models.lite_llm._message_to_generate_content_response` with
+`json.loads(...)` UNGUARDED in the non-streaming path (lite_llm.py:1630) — a
+`JSONDecodeError` there kills the WHOLE run (the streaming path :2158 is guarded).
+
+`install_json_repair()` swaps the module-global `json` inside lite_llm with a shim
+whose `.loads()` repairs ON FAILURE ONLY (json_repair → valid-prefix salvage →
+bracket-balancing heuristic → `{}`), covering both parse sites. SUCCESS behavior is
+unchanged. This is process-wide once installed.
+"""
+from __future__ import annotations
+
+import json as _json
+import re
+
+
+def repair_json_loads(s):
+    """Parse JSON, repairing common LLM malformations on failure. Last resort: {}."""
+    if not isinstance(s, str):
+        return s
+    try:
+        return _json.loads(s)
+    except _json.JSONDecodeError:
+        pass
+    # 1) json_repair — purpose-built for malformed LLM JSON (truncation, commas, quotes)
+    try:
+        import json_repair
+        out = json_repair.loads(s)
+        if out not in (None, ""):
+            return out
+    except Exception:
+        pass
+    # 2) salvage a valid prefix (handles trailing garbage / "Extra data")
+    try:
+        obj, _end = _json.JSONDecoder().raw_decode(s.strip())
+        return obj
+    except Exception:
+        pass
+    # 3) heuristic: drop a trailing comma, balance unclosed brackets (handles truncation)
+    t = re.sub(r",\s*$", "", s.strip())
+    t = t + "]" * max(0, t.count("[") - t.count("]")) + "}" * max(0, t.count("{") - t.count("}"))
+    try:
+        return _json.loads(t)
+    except Exception:
+        return {}  # better empty args (tool re-decides / re-prompts) than a dead run
+
+
+class _RepairJsonModule:
+    """Drop-in for the `json` module name used inside lite_llm; repairs on failure."""
+
+    JSONDecodeError = _json.JSONDecodeError
+    JSONDecoder = _json.JSONDecoder
+
+    def loads(self, s, *args, **kwargs):
+        try:
+            return _json.loads(s, *args, **kwargs)
+        except _json.JSONDecodeError:
+            return repair_json_loads(s)
+
+    def dumps(self, *args, **kwargs):
+        return _json.dumps(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(_json, name)
+
+
+_installed = False
+
+
+def install_json_repair() -> bool:
+    """Patch lite_llm's `json` with the repair shim. Idempotent; returns True if applied."""
+    global _installed
+    if _installed:
+        return True
+    try:
+        import google.adk.models.lite_llm as _ll
+        _ll.json = _RepairJsonModule()
+        _installed = True
+        return True
+    except Exception:
+        return False

--- a/CoScientist/agents/prompts/templates.py
+++ b/CoScientist/agents/prompts/templates.py
@@ -637,6 +637,16 @@ def planner(ctx: PromptContext) -> str:
 You are the "PlannerAgent". Your goal is to decompose the task and create a roadmap by registering tasks using the `create_plan` tool.
 You only define procedural steps and references agents.
 
+### TOOL DISCOVERY (do this FIRST)
+Before writing the plan, call `retrieve_tools` with one or two focused queries
+about the task's core capabilities (e.g. "molecule generation", "property
+prediction"). Read each returned tool's FULL description — what it
+RETURNS and which arguments (`input_schema`) it accepts. Let this shape the plan:
+do NOT add a separate step for something a tool already does as part of another
+step (e.g. if a generator already returns molecular properties, do not add a
+standalone property-calculation step). Do not invent tools or server ids; if
+discovery returns nothing relevant, plan from your own knowledge. DO NOT CALL TOOLS YOURSELF — the orchestrator will delegate to the appropriate agent.
+
 ### AVAILABLE AGENTS
 <<ROSTER>>
 

--- a/CoScientist/agents/system.yaml
+++ b/CoScientist/agents/system.yaml
@@ -104,7 +104,10 @@ agents:
       for a complex multi-step task, call this FIRST to produce a roadmap,
       then follow it step by step.
     prompt: planner
-    tools: [create_plan_tool]
+    # retrieval lets the planner inspect which ready-made MCP tools exist (and
+    # what they accept/return) BEFORE writing the roadmap, so the plan reflects
+    # real tool capabilities instead of guessing from priors.
+    tools: [retrieval, create_plan_tool]
     output_key: planner_roadmap
     hitl: true
     a2a:

--- a/CoScientist/main.py
+++ b/CoScientist/main.py
@@ -34,6 +34,36 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _s3_csv_preview(url: str, max_rows: int = 10, max_bytes: int = 200_000) -> str:
+    """Best-effort: download a presigned-S3 CSV and return a small text preview
+    (header + first rows of Smiles + key property columns). Returns '' on any failure.
+
+    Lets the final answer be formed from the ACTUAL S3 file contents rather than a bare
+    link or unverified prose (F010.A6).
+    """
+    import urllib.request
+    import csv
+    import io
+    try:
+        with urllib.request.urlopen(url, timeout=20) as resp:
+            raw = resp.read(max_bytes).decode("utf-8", "replace")
+        rows = list(csv.reader(io.StringIO(raw)))
+        if not rows:
+            return ""
+        hdr = rows[0]
+        prefer = ("Smiles", "QED", "LogP", "Synthetic Accessibility", "Validity")
+        keep = [i for i, h in enumerate(hdr) if h in prefer] or list(range(min(5, len(hdr))))
+        out = [" | ".join(hdr[i] for i in keep)]
+        for row in rows[1:1 + max_rows]:
+            out.append(" | ".join(row[i] if i < len(row) else "" for i in keep))
+        extra = len(rows) - 1 - max_rows
+        if extra > 0:
+            out.append(f"… (+{extra} more rows)")
+        return "\n".join(out)
+    except Exception:
+        return ""
+
+
 class CoScientistManager:
     """
     Main manager for CoScientist (ADK-based execution).
@@ -103,23 +133,86 @@ class CoScientistManager:
         )
 
         final_response = "No response"
+        run_error = None
 
-        async for event in self.runner.run_async(
-            user_id=self.user_id,
-            session_id=self.session_id,
-            new_message=content,
-        ):
-            if verbose:
-                print(
-                    f"[Event] {event.author} | {type(event).__name__} | Final={event.is_final_response()}"
+        # Partial delivery (F015a.A4 #2): a mid-run failure — notably an MCP 300s
+        # timeout / McpError on a slow tool — must NOT discard results already
+        # captured at the tool boundary (state['fedot_artifacts']). Swallow it here
+        # and fall through to the deterministic finalizer below, which surfaces those
+        # artifacts so the user still gets the molecules produced before the stall.
+        try:
+            async for event in self.runner.run_async(
+                user_id=self.user_id,
+                session_id=self.session_id,
+                new_message=content,
+            ):
+                if verbose:
+                    print(
+                        f"[Event] {event.author} | {type(event).__name__} | Final={event.is_final_response()}"
+                    )
+
+                if event.is_final_response():
+                    if event.content and event.content.parts:
+                        parts = event.content.parts
+                        # Thinking models emit a separate `thought` part before the
+                        # answer; parts[0] is often that reasoning. Prefer the
+                        # non-thought answer text, falling back to any text so we
+                        # never drop the response entirely.
+                        answer = "\n".join(
+                            p.text for p in parts
+                            if getattr(p, "text", None) and not getattr(p, "thought", False)
+                        )
+                        final_response = answer or "\n".join(
+                            p.text for p in parts if getattr(p, "text", None)
+                        ) or ""
+                    elif event.actions and event.actions.escalate:
+                        final_response = f"Escalation: {getattr(event, 'error_message', None) or 'Unknown error'}"
+        except Exception as exc:
+            run_error = exc
+            logger.error(
+                f"run loop raised ({type(exc).__name__}: {str(exc)[:200]}); "
+                "attempting partial delivery from captured S3 artifacts."
+            )
+
+        # Deterministic finalizer (F010.A5/A6): the orchestrator LLM sometimes drops a
+        # successfully-generated result. The real molecules live behind a presigned S3 URL
+        # that fedot_tool captured into state['fedot_artifacts']. If that result is not
+        # already in the answer, DOWNLOAD the file and append a preview of its contents (read
+        # from S3, not fabricated) plus the link, so generated molecules always reach the user.
+        try:
+            session = await self.session_service.get_session(
+                app_name=self.app_name, user_id=self.user_id, session_id=self.session_id,
+            )
+            arts = (getattr(session, "state", None) or {}).get("fedot_artifacts") if session else None
+        except Exception:
+            arts = None
+        if arts:
+            missing = [a for a in arts if a.get("url") and a["url"] not in (final_response or "")]
+            if missing:
+                blocks = []
+                for a in missing:
+                    url = a["url"]
+                    cnt = a.get("generated_count")
+                    tag = f" ({cnt} molecules)" if cnt else ""
+                    preview = await asyncio.to_thread(_s3_csv_preview, url)
+                    block = f"**Generated molecules{tag}** — [download full CSV]({url})"
+                    if preview:
+                        block += f"\n```\n{preview}\n```"
+                    blocks.append(block)
+                final_response = (final_response or "").rstrip() + "\n\n---\n" + "\n\n".join(blocks)
+
+        if not (final_response or "").strip():
+            if run_error is not None:
+                final_response = (
+                    f"The run stopped early ({type(run_error).__name__}) before producing a result, "
+                    "and no partial artifacts were captured. This is usually a slow MCP tool hitting "
+                    "its timeout or a transient model/network error — please retry."
                 )
-
-            if event.is_final_response():
-                if event.content and event.content.parts:
-                    final_response = event.content.parts[0].text or ""
-                elif event.actions and event.actions.escalate:
-                    final_response = f"Escalation: {getattr(event, 'error_message', None) or 'Unknown error'}"
-
+            else:
+                final_response = (
+                    "I couldn't complete this request within the available steps — the orchestrator "
+                    "did not reach a tool that produced a result. Please retry or narrow the request."
+                )
 
         return final_response
 

--- a/CoScientist/storage/models.py
+++ b/CoScientist/storage/models.py
@@ -11,6 +11,10 @@ class RetrievalToolResult(BaseModel):
     tool: str
     server_id: str
     description: str
+    input_schema: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="JSON schema of the tool's accepted arguments (from the registry).",
+    )
     score: float
 
 class ToolScore(BaseModel):

--- a/CoScientist/tools/fedot_artifact_plugin.py
+++ b/CoScientist/tools/fedot_artifact_plugin.py
@@ -1,0 +1,90 @@
+"""Deterministic capture of S3 artifact links produced by MCP tools inside a FEDOT.MAS run.
+
+Why (F010.A3): mol-gen / ML MCP tools (`generate_mols`, `generate_case_mols`,
+`predict_ml`, …) are remote and do not return their data inline — they upload it to S3
+and return a *presigned URL* to a results CSV. The FEDOT.MAS sub-agent (an ADK
+``LlmAgent``) keeps only its free-text paraphrase under ``output_key``, so the raw
+structured link is dropped — and the sub-agent can hallucinate SMILES that were never in
+the tool output.
+
+Fix seam (no fedotmas fork): ``MAS(plugins=[...])`` is threaded to the ADK ``Runner``.
+This ``BasePlugin.after_tool_callback`` fires at the tool-call boundary, BEFORE the LLM
+paraphrase, and stashes every S3 link it sees into its own ``captured`` list (owned by
+the caller — no reliance on cross-stage session-state merge).
+
+ADK passes ``after_tool_callback`` the result of
+``CallToolResult.model_dump(exclude_none=True, mode="json")`` (mcp_tool.py) — i.e. the
+WRAPPED MCP envelope ``{content:[{text:<json>}], structuredContent:{...}, isError}``,
+NOT the tool's top-level dict (F010.A4). The link therefore lives under
+``structuredContent`` (or as a JSON string inside ``content[].text``), so the extractor
+searches RECURSIVELY for any dict carrying a ``*presigned_url`` key, parsing JSON-looking
+strings on the way down.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from google.adk.plugins import BasePlugin
+
+
+def _is_artifact_dict(d: dict) -> bool:
+    return any(
+        k.endswith("presigned_url") and isinstance(v, str) and v
+        for k, v in d.items()
+    )
+
+
+def _walk_for_s3(obj: Any, found: list) -> None:
+    """Recursively collect dicts that carry a ``*presigned_url`` key. Handles ADK's
+    CallToolResult envelope and JSON-string content blocks."""
+    if isinstance(obj, dict):
+        if _is_artifact_dict(obj):
+            found.append(obj)
+        for v in obj.values():
+            _walk_for_s3(v, found)
+    elif isinstance(obj, list):
+        for v in obj:
+            _walk_for_s3(v, found)
+    elif isinstance(obj, str) and "presigned_url" in obj:
+        try:
+            _walk_for_s3(json.loads(obj), found)
+        except Exception:
+            pass
+
+
+def _normalize(d: dict, tool_name: str | None) -> dict:
+    url = next((v for k, v in d.items() if k.endswith("presigned_url") and v), None)
+    return {
+        "url": url,
+        "s3_key": d.get("results_s3_key") or d.get("s3_key"),
+        "bucket": d.get("bucket_name") or d.get("bucket"),
+        "columns": d.get("columns"),
+        "generated_count": d.get("generated_count"),
+        "case": d.get("case"),
+        "tool": tool_name,
+    }
+
+
+class ArtifactCapturePlugin(BasePlugin):
+    """Capture S3 artifact links from tool results before the LLM can drop them."""
+
+    def __init__(self, name: str = "artifact_capture") -> None:
+        super().__init__(name)
+        self.captured: list[dict] = []
+
+    def _add(self, art: dict) -> None:
+        key = (art.get("tool"), art.get("s3_key") or art.get("url"))
+        if art.get("url") and key not in {
+            (a.get("tool"), a.get("s3_key") or a.get("url")) for a in self.captured
+        }:
+            self.captured.append(art)
+
+    async def after_tool_callback(self, *, tool, tool_args, tool_context, result):  # noqa: ANN001
+        tool_name = getattr(tool, "name", None)
+        found: list = []
+        _walk_for_s3(result, found)
+        for d in found:
+            self._add(_normalize(d, tool_name))
+        return None  # never mutate the tool result itself

--- a/CoScientist/tools/fedotmas_tools.py
+++ b/CoScientist/tools/fedotmas_tools.py
@@ -8,7 +8,9 @@ from google.adk.tools.base_toolset import BaseToolset
 from google.adk.agents.readonly_context import ReadonlyContext
 
 from fedotmas import MAS, HttpMCPServer
+from fedotmas.plugins import LoggingPlugin, WebSearchLimitPlugin
 
+from CoScientist.tools.fedot_artifact_plugin import ArtifactCapturePlugin
 from rag_tools import MCPServer
 from rag_tools.storage import PostgresClient
 from rag_tools.config.settings import get_settings
@@ -67,16 +69,54 @@ class FedotMASToolset(BaseToolset):
         }
         servers_payload.update(web_servers_payload)
 
+        # F010.A3/A4: an after_tool_callback plugin captures S3 artifact links
+        # (results_presigned_url) at the tool-call boundary, BEFORE FEDOT.MAS sub-agents
+        # paraphrase them away / hallucinate molecules.
+        # NB: passing plugins= REPLACES MAS defaults, so re-include them.
+        cap = ArtifactCapturePlugin()
+        # NOTE (F015): do NOT impose a short FEDOT timeout — confirm the pipeline produces
+        # CORRECT results first, optimize stage latency later. timeout=None = unbounded.
+        # The except branch below still returns captured artifacts on a FEDOT error, so a
+        # link produced before a failure is never lost.
+        FEDOT_TIMEOUT_S = None
+        result = None
+        status, err = "success", None
         try:
-            mas = MAS(mcp_servers=servers_payload)
-            result = await mas.run(task_description)
+            mas = MAS(
+                mcp_servers=servers_payload,
+                plugins=[LoggingPlugin(), WebSearchLimitPlugin(max_calls_per_agent=4), cap],
+            )
+            result = await mas.run(task_description, timeout=FEDOT_TIMEOUT_S)
+        except (asyncio.TimeoutError, TimeoutError):
+            status, err = "timeout", f"FEDOT.MAS exceeded {FEDOT_TIMEOUT_S}s"
         except Exception as e:
-            return {"status": "error", "error": f"FEDOT.MAS run failed: {e}"}
+            status, err = "error", f"FEDOT.MAS run failed: {e}"
 
-        return {
-            "status": "success",
-            "result": result,
-        }
+        # Fallback (F010.A4): scan the final MAS state for presigned URLs the plugin may
+        # have missed (only when a result actually came back).
+        if result is not None:
+            import re as _re
+            import json as _json
+            try:
+                _txt = _json.dumps(result, default=str, ensure_ascii=False)
+            except Exception:
+                _txt = str(result)
+            _known = {a.get("url") for a in cap.captured}
+            for _u in dict.fromkeys(_re.findall(r"https?://[^\s\"'<>)\\]+X-Amz-[^\s\"'<>)\\]+", _txt)):
+                if _u not in _known:
+                    cap.captured.append({"url": _u, "tool": "fedot_state_scan"})
+
+        # Surface the REAL artifacts in the return value AND shared session state — so the
+        # link survives even when FEDOT.MAS timed out AFTER generation (F015 Mode B fix).
+        if cap.captured and tool_context is not None:
+            tool_context.state["fedot_artifacts"] = cap.captured
+
+        ret = {"status": status, "artifacts": cap.captured}
+        if result is not None:
+            ret["result"] = result
+        if err:
+            ret["error"] = err
+        return ret
 
     
 fedot_toolset = FedotMASToolset()

--- a/CoScientist/tools/retrieval_tools.py
+++ b/CoScientist/tools/retrieval_tools.py
@@ -1,6 +1,7 @@
 """Tools for fedotmas inference"""
 
 import asyncio
+import logging
 from typing import List, Optional, Dict, Any
 
 from google.adk.tools import BaseTool, ToolContext
@@ -16,6 +17,56 @@ from rag_tools.retrieval import APIEmbedder, APIReranker, BM25Reranker, HybridRe
 from rag_tools.storage.models import RetrievalResult
 
 settings = get_settings()
+_logger = logging.getLogger(__name__)
+
+# The full description + input_schema are returned INLINE to the calling agent
+# (planner/orchestrator) in each retrieve_tools response. The session-state
+# `accumulated_tools` is re-injected into the downstream rerankers' prompts on
+# every turn, so there we keep a capped description and drop the schema to avoid
+# unbounded context bloat (and the schema-validation pressure it puts on the
+# structured-output rerankers).
+_ACCUM_DESC_CAP = 600
+
+
+async def _fetch_full_tool_meta(server_ids) -> Dict[tuple, Dict[str, Any]]:
+    """Map ``(server_id, tool_name) -> {description, input_schema}`` from the registry.
+
+    The RAG retrieval path returns a truncated description chunk and no schema;
+    the full, authoritative tool metadata lives in the Postgres registry. We
+    fetch it once per unique server. Best-effort: a server that fails to resolve
+    is simply skipped (the caller falls back to the RAG chunk).
+    """
+    meta: Dict[tuple, Dict[str, Any]] = {}
+    if not server_ids:
+        return meta
+    postgres = PostgresClient(settings.postgres)
+    try:
+        await postgres.initialize()
+        for sid in server_ids:
+            try:
+                tools = await postgres.get_tools_by_server(sid)
+            except Exception as exc:
+                _logger.warning(
+                    "retrieve_tools: could not fetch full metadata for server %r: %s",
+                    sid, exc,
+                )
+                continue
+            for t in tools:
+                name = getattr(t, "name", None)
+                if not name:
+                    continue
+                schema = getattr(t, "input_schema", None)
+                if schema is not None and not isinstance(schema, dict):
+                    # pydantic model / other -> plain dict for JSON serialisation
+                    dump = getattr(schema, "model_dump", None)
+                    schema = dump() if callable(dump) else getattr(schema, "__dict__", None)
+                meta[(sid, name)] = {
+                    "description": getattr(t, "description", None),
+                    "input_schema": schema,
+                }
+    finally:
+        await postgres.close()
+    return meta
 
 
 class RetrievalToolSet(BaseToolset):
@@ -64,11 +115,20 @@ class RetrievalToolSet(BaseToolset):
                 rerank_top_k=settings.rag.rerank_top_k,
                 min_score=settings.rag.min_relevance_score)
 
+            # The RAG layer returns only a truncated (~chunk_size) chunk of each
+            # tool's description and drops its argument schema — so the calling
+            # agent never sees what a tool RETURNS or which arguments it accepts.
+            # Re-fetch the FULL description + input_schema from the registry.
+            full_meta = await _fetch_full_tool_meta(
+                {r.server_id for r in retrieved_tools}
+            )
+
             results = [
                 RetrievalToolResult(
                     tool=r.name,
                     server_id=r.server_id,
-                    description=r.description,
+                    description=full_meta.get((r.server_id, r.name), {}).get("description") or r.description,
+                    input_schema=full_meta.get((r.server_id, r.name), {}).get("input_schema"),
                     score=r.rerank_score,
                 )
                 for r in retrieved_tools
@@ -95,7 +155,9 @@ class RetrievalToolSet(BaseToolset):
                 accumulated.append({
                     'tool': tool_result.tool,
                     'server_id': tool_result.server_id,
-                    'description': tool_result.description,
+                    # Capped here (not in the inline response) — this dict is
+                    # re-injected into the rerankers' prompts every turn.
+                    'description': (tool_result.description or "")[:_ACCUM_DESC_CAP],
                     'score': tool_result.score,
                     'tool_index': last_idx,
                     'retrieval_query': query,  # Track which query found this
@@ -124,11 +186,12 @@ class RetrievalToolSet(BaseToolset):
         """
 
         postgres = PostgresClient(settings.postgres)
-        await postgres.initialize()
-
-        server: MCPServer = await postgres.get_server(server_id)
-
-        await postgres.close()
+        try:
+            await postgres.initialize()
+            server: MCPServer = await postgres.get_server(server_id)
+        finally:
+            # Always release the DB connection, even if the lookup raises.
+            await postgres.close()
 
         return {
             "status": "success",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "boto3>=1.43.32",
     "fedotmas",
     "google-adk>=2.3.0",
+    "json-repair>=0.30.0",
     "langchain-text-splitters>=1.1.2",
     "metapub>=0.7.4",
     "opik>=2.0.70",

--- a/uv.lock
+++ b/uv.lock
@@ -521,6 +521,7 @@ dependencies = [
     { name = "boto3" },
     { name = "fedotmas" },
     { name = "google-adk" },
+    { name = "json-repair" },
     { name = "langchain-text-splitters" },
     { name = "metapub" },
     { name = "opik" },
@@ -534,6 +535,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.32" },
     { name = "fedotmas", git = "https://github.com/ITMO-NSS-team/FEDOT.MAS.git?subdirectory=packages%2Ffedotmas" },
     { name = "google-adk", specifier = ">=2.3.0" },
+    { name = "json-repair", specifier = ">=0.30.0" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "metapub", specifier = ">=0.7.4" },
     { name = "opik", specifier = ">=2.0.70" },
@@ -1300,6 +1302,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
+]
+
+[[package]]
+name = "json-repair"
+version = "0.61.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/c0/1cb689126eacd166fd5a78370f095c7d3a250808dabeda129300e5280110/json_repair-0.61.0.tar.gz", hash = "sha256:48759cc6c3052814c797d1d56787d9e1d451603a8760a55d619e97d2f49353d6", size = 50055, upload-time = "2026-06-16T12:18:33.32Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/b9/e996902245d5e12e55b0b2e667d3e83a4636dec3692e405e5b8ea0868263/json_repair-0.61.0-py3-none-any.whl", hash = "sha256:ee9fe5f95fcb2713d72d4495b67b794b62ff2cd24d6dba3bfb3173d9f7ab0f7d", size = 48490, upload-time = "2026-06-16T12:18:31.883Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Result fidelity & robustness
- llm_repair: install a JSON-repair shim on the LiteLlm tool-call boundary
  so malformed tool_call.arguments (qwen truncation / missing comma) no
  longer kills the run. Repairs on failure only; success path unchanged.
  Installed process-wide at agents-package import.
- fedot_artifact_plugin (ArtifactCapturePlugin): capture S3 presigned-URL
  artifacts at the tool-call boundary before FEDOT.MAS sub-agents paraphrase
  them away or hallucinate SMILES; walks ADK's CallToolResult envelope
  (structuredContent / JSON-string content) recursively.
- fedotmas_tools: thread the plugin (+ Logging/WebSearchLimit) into MAS,
  drop the short FEDOT timeout (timeout=None), and return/persist captured
  artifacts (state['fedot_artifacts']) even on FEDOT error/timeout, with a
  final-state presigned-URL fallback scan.
- main: swallow a mid-run MCP timeout/McpError and fall through to a
  deterministic finalizer that surfaces captured artifacts (partial
  delivery); prefer the non-thought answer part from thinking models;
  add _s3_csv_preview to build the answer from the actual S3 CSV
  (header + SMILES + property columns) rather than a bare link.

Tool discovery
- retrieve_tools: return each tool's FULL registry description + input_schema
  (the RAG layer returned only a truncated chunk and no schema); cap the
  long-lived accumulated_tools description to keep reranker prompts lean;
  fix a get_server_info connection leak; add warn logging on lookup failure.
- PlannerAgent: attach the retrieval toolset and instruct it to discover
  tools (what they return / accept) before writing the roadmap.