### PR TITLE
Per-user OpenAlex credentials via HTTP headers on papers-search MCP

### DIFF
--- a/CoScientist/config/settings.py
+++ b/CoScientist/config/settings.py
@@ -49,6 +49,7 @@ class LLMSettings(BaseModel):
 class ServicesSettings(BaseModel):
     tavily_api_key: Optional[str] = None
     openalex_api_key: Optional[str] = None
+    openalex_email: Optional[str] = None
 
 
 # =========================

--- a/CoScientist/tools/research_tools.py
+++ b/CoScientist/tools/research_tools.py
@@ -14,7 +14,11 @@ PAPERS_SEARCH_URL = settings.mcp.papers_search_url
 
 _PAPER_ANALYSIS_TIMEOUT = 60 * 15.0  # 30 min — processing many PDFs is slow
 
-def _http_mcp_toolset(url: Optional[str], sse_read_timeout: float = 60 * 5.0) -> Optional[McpToolset]:
+def _http_mcp_toolset(
+    url: Optional[str],
+    sse_read_timeout: float = 60 * 5.0,
+    headers: Optional[dict] = None,
+) -> Optional[McpToolset]:
     """Build an HTTP MCP toolset, or None when the URL is not configured.
 
     Returning None (instead of crashing at import on a missing URL) lets the app
@@ -23,7 +27,13 @@ def _http_mcp_toolset(url: Optional[str], sse_read_timeout: float = 60 * 5.0) ->
     """
     if not url:
         return None
-    return McpToolset(connection_params=StreamableHTTPConnectionParams(url=url, sse_read_timeout=sse_read_timeout))
+    return McpToolset(
+        connection_params=StreamableHTTPConnectionParams(
+            url=url,
+            sse_read_timeout=sse_read_timeout,
+            headers=headers or {},
+        )
+    )
 
 
 # Tavily websearch is always available (the key is interpolated into the URL).
@@ -36,4 +46,15 @@ websearch_toolset_instance = McpToolset(
 # Optional paper-analysis / paper-search MCP servers — only built when configured
 # (MCP__PAPER_ANALYSIS_URL / MCP__PAPERS_SEARCH_URL in .env).
 paper_analysis_toolset_instance = _http_mcp_toolset(PAPER_ANALYSIS_URL, sse_read_timeout=_PAPER_ANALYSIS_TIMEOUT)
-papers_search_toolset_instance = _http_mcp_toolset(PAPERS_SEARCH_URL)
+
+# Per-user OpenAlex credentials forwarded as HTTP headers so the shared remote
+# container uses each caller's own rate-limit quota instead of the server's env.
+_openalex_headers = {
+    k: v
+    for k, v in {
+        "x-openalex-email": settings.services.openalex_email,
+        "x-openalex-api-key": settings.services.openalex_api_key,
+    }.items()
+    if v
+}
+papers_search_toolset_instance = _http_mcp_toolset(PAPERS_SEARCH_URL, headers=_openalex_headers)

--- a/mcp-servers/papers-search-mcp-server/.env.example
+++ b/mcp-servers/papers-search-mcp-server/.env.example
@@ -1,6 +1,3 @@
-OPENALEX_API_KEY='api-key'
-OPENALEX_EMAIL='your-email'
-
 ENDPOINT_URL='http://0.0.0.0:9000'
 ACCESS_KEY='username'
 SECRET_KEY='password'

--- a/mcp-servers/papers-search-mcp-server/papers_search_server.py
+++ b/mcp-servers/papers-search-mcp-server/papers_search_server.py
@@ -4,14 +4,10 @@ from io import BytesIO
 import logging
 
 from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_http_request
 
 from CoScientist.paper_parser.s3_connection import S3BucketService
 from openalex_client import OpenAlexClient
-
-OPENALEX_EMAIL = os.getenv("OPENALEX_EMAIL")
-OPENALEX_API_KEY = os.getenv("OPENALEX_API_KEY")
-
-openalex_client = OpenAlexClient(email=OPENALEX_EMAIL)
 
 s3_service = S3BucketService(
     endpoint=os.getenv("ENDPOINT_URL"),
@@ -23,6 +19,12 @@ s3_service = S3BucketService(
 mcp = FastMCP("PapersSearch")
 
 
+def _get_credentials() -> tuple[str | None, str | None]:
+    """Return (email, api_key) from request headers."""
+    headers = get_http_request().headers
+    return headers.get("x-openalex-email"), headers.get("x-openalex-api-key")
+
+
 def _sanitize_filename(name: str) -> str:
     return re.sub(r'[\\/*?:"<>|]', "", name)
 
@@ -31,12 +33,14 @@ def search_entity(entity_type: str, entity_name: str) -> dict:
     """
     Search for an entity (author, source, institution) in OpenAlex and return its ID.
     This ID can be further used to search for papers using the search_papers or download_papers_from_search tools.
-    
+
     Args:
         entity_type: Type of entity to search for ("author", "source", "institution")
         entity_name: Name of the entity to search for (e.g., author name, journal name, institution name)
     """
-    result = openalex_client.search_entity(entity_type=entity_type, entity_name=entity_name)
+    email, _ = _get_credentials()
+    client = OpenAlexClient(email=email)
+    result = client.search_entity(entity_type=entity_type, entity_name=entity_name)
     if result:
         return {'answer': f'Entity ID: {result["id"]}'}
     else:
@@ -69,7 +73,9 @@ def search_papers(
         limit: Max number of results
         sort: OpenAlex sort field (e.g., "cited_by_count:desc")
     """
-    response = openalex_client.search_works(
+    email, _ = _get_credentials()
+    client = OpenAlexClient(email=email)
+    response = client.search_works(
         keywords=keywords,
         author_id=author_id,
         institution_id=institution_id,
@@ -88,7 +94,6 @@ def search_papers(
     papers = []
     for work in works:
         location = work.get("primary_location") or {}
-        primary_loc = work.get("primary_location") or {}
         papers.append(
             {
                 "title": work.get("title"),
@@ -119,7 +124,9 @@ def download_papers_from_search(
     user_id: str = "1",
 ) -> dict:
     """Search papers in OpenAlex and upload found PDFs directly to S3."""
-    response = openalex_client.search_works(
+    email, api_key = _get_credentials()
+    client = OpenAlexClient(email=email)
+    response = client.search_works(
         keywords=keywords,
         author_id=author_id,
         institution_id=institution_id,
@@ -147,7 +154,7 @@ def download_papers_from_search(
         file_name = f"{_sanitize_filename(title)}.pdf"
         s3_key = f"{s3_prefix.rstrip('/')}/{file_name}"
 
-        response = openalex_client.request_with_retry(endpoint=pdf_url, params={"api_key": OPENALEX_API_KEY})
+        response = client.request_with_retry(endpoint=pdf_url, params={"api_key": api_key})
         destination_path = f"{s3_prefix.rstrip('/')}/{file_name}"
         s3_client.upload_fileobj(BytesIO(response.content), s3_service.bucket_name, destination_path)
         logging.info(f"Uploaded paper '{title}' to S3 at {destination_path}")
@@ -173,4 +180,3 @@ def download_papers_from_search(
 
 if __name__ == "__main__":
     mcp.run(transport="http", host="0.0.0.0", port=7331, path="/mcp")
-


### PR DESCRIPTION
сделала так, чтобы каждый пользователь мог установить свои креды для OpenAlex, не перезапуская при этом контейнер