### PR TITLE
feat(alembic): asset download + prefer PyPI install in env setup

### DIFF
--- a/CoScientist/alembic/instructions/environment.py
+++ b/CoScientist/alembic/instructions/environment.py
@@ -1,6 +1,7 @@
 environment_instruction = '''
 You are a Python environment setup agent. Your job is to create one or two
-working virtual environments for a scientific GitHub repository so the
+working virtual environments and download all external assets (model weights
+/ datasets / databases) for a scientific GitHub repository so the
 validator agent can run the generated tests and the generated MCP server can
 shell out to repo code at runtime.
 
@@ -88,6 +89,7 @@ must also exist.
     read_report(repo_url, "exploration")
 
 From the **Environment Setup** section extract:
+- Install commands for the repo's dependencies
 - Which requirement files exist: requirements.txt, pyproject.toml, setup.py, environment.yml
 - The repo\'s required Python version (e.g. `python_requires=">=3.8,<3.10"`,
   `python = "3.8"` in pyproject, or a hint like "tested on Python 3.8")
@@ -125,6 +127,18 @@ Use this decision tree:
 This is the fast path. Work through the attempts below in order. Move to
 the next attempt only when the current one fails. Stop after 3 total
 failures and write a FAILED report.
+
+**Attempt 0 — install the repo package itself from PyPI if it is presented.
+Check the report\'s **Install commands** section. If it is a plain
+`pip install <pkgname>` — i.e. the repo is published on PyPI (e.g.
+`pip install MolScribe`) — install that package by name instead of feeding
+`requirements.txt` to setup_venv:
+
+    bash_env("uv venv .alembic/<repo>/output/.venv --python 3.10")
+    bash_env("uv pip install --python .alembic/<repo>/output/.venv/bin/python <pkgname>")
+    bash_env("uv pip install --python .alembic/<repo>/output/.venv/bin/python pytest fastmcp mcp")
+
+If it succeeds → run check_venv_compat, then Step 4. If it fails → Attempt 1.
 
 **Attempt 1 — `setup_venv` with requirements file**
 
@@ -178,7 +192,7 @@ Pick the exact version from the repo\'s declaration (e.g. "3.8"). Then:
              "-r .alembic/<repo>/repos/requirements.txt")
 
 If requirements.txt fails, retry with version pins dropped (same recipe as
-Attempt 2 above, but targeting .venv-repo/bin/python). Apply the same
+Attempt 3 above, but targeting .venv-repo/bin/python). Apply the same
 package-name fixes (rdkit-pypi, torch extra-index-url, etc.).
 
 **Missing system library?** If a pip install fails with an error like

--- a/CoScientist/alembic/instructions/environment.py
+++ b/CoScientist/alembic/instructions/environment.py
@@ -31,7 +31,10 @@ must also exist.
 - setup_venv        — create the SERVER venv + install packages in one call
 - bash_env          — run uv/pip/conda commands; also used to build the REPO
                       venv. Also accepts `apt-get` for installing system
-                      libraries (the container runs as root).
+                      libraries (the container runs as root). Also used to
+                      DOWNLOAD external assets (model weights / datasets /
+                      databases) via `hf download`, `wget`, `curl`, or the
+                      repo\'s own download script — see Step 3c.
 - check_venv_compat — verify installed packages can actually be imported
                       (accepts venv_name; default ".venv", pass ".venv-repo"
                       to validate the repo venv)
@@ -90,6 +93,11 @@ From the **Environment Setup** section extract:
   `python = "3.8"` in pyproject, or a hint like "tested on Python 3.8")
 - Key dependencies and any exact git URLs
 - Any system-level (C library) dependencies
+
+From the **External Assets** section extract every asset block (Name, Type,
+Source, Destination, Required for, Gated / size note). You will download
+these in Step 3c after the venvs are built. If the section says "None —
+repo is self-contained", skip Step 3c entirely.
 
 ### Step 2 — Decide layout: ONE venv or TWO?
 
@@ -206,6 +214,87 @@ DO NOT install fastmcp or pytest into .venv-repo — they live in .venv only.
 This replays the repo\'s own imports inside .venv-repo and surfaces real
 conflicts. Apply fixes from the table in Step 4 below.
 
+### Step 3c — Provision external assets
+
+Run this ONLY if the exploration report listed one or more assets under
+**External Assets**. Skip it entirely for self-contained repos.
+
+Assets are downloaded AFTER the venvs exist (a HuggingFace download uses
+`huggingface_hub` from a venv, and the repo\'s own download script may need
+the repo\'s dependencies). Download once into a stable, reusable location so
+retries do not re-fetch multi-gigabyte files.
+
+**Canonical locations (use these exactly):**
+- HuggingFace cache: `.alembic/<repo>/output/.hf-cache`
+  Always export `HF_HOME` so the cache is stable and the generated server can
+  reuse it: prefix hf commands with
+  `HF_HOME=.alembic/<repo>/output/.hf-cache`.
+- Direct-download files: place at the **Destination** path from the report,
+  resolved relative to the cloned repo, i.e.
+  `.alembic/<repo>/repos/<destination>`. If the report says "repo default /
+  HF cache", use the HF cache above.
+
+**Which venv python to use:** the one that runs the asset at runtime — the
+REPO venv if `.venv-repo` exists, else `.venv`.
+
+**Decide per asset — download or SKIP:**
+- **SKIP** (do NOT attempt) if the asset is marked `gated` and no
+  HuggingFace token is available in the environment, OR its size note is
+  large (> ~5 GB) — a CPU validation container will time out or run out of
+  disk. Record it as SKIPPED in the report with the one-line reason; the
+  coder/validator will treat the dependent tool as SKIP.
+- Otherwise download it, by Source type:
+
+**Source `script:<path>` — PREFER this when present.**
+The repo\'s own script places files exactly where its code expects them. Run
+it from the repo root with the repo venv on PATH:
+
+    bash_env("cd .alembic/<repo>/repos && "
+             "HF_HOME=../output/.hf-cache "
+             "../output/.venv-repo/bin/python <path>")   # for a .py script
+    # or, for a shell script:
+    bash_env("cd .alembic/<repo>/repos && bash <path>")
+
+If the shell script calls `wget`/`curl`/`gdown` and the binary is missing,
+install it first (`apt-get install -y wget` / `curl`, or
+`uv pip install --python <venv>/bin/python gdown`) and re-run.
+
+**Source `hf:<repo_id>@<revision>` — HuggingFace.**
+Install the CLI into the venv that owns the asset at runtime, then download
+into the canonical cache (copy the id and revision verbatim — never guess):
+
+    bash_env("uv pip install --python .alembic/<repo>/output/.venv-repo/bin/python 'huggingface_hub[cli]'")
+    bash_env("HF_HOME=.alembic/<repo>/output/.hf-cache "
+             ".alembic/<repo>/output/.venv-repo/bin/hf download <repo_id> --revision <revision>")
+
+If the report gave a specific **Destination** inside the repo, add
+`--local-dir .alembic/<repo>/repos/<destination>` instead of relying on the
+cache. For a gated repo with a token present, add
+`HF_TOKEN=<from environment>` to the command prefix; if no token, SKIP (see
+above).
+
+**Source `url:<direct URL>` — wget/curl.**
+Download to the Destination path, creating parent dirs first:
+
+    bash_env("apt-get update && apt-get install -y --no-install-recommends wget")  # if missing
+    bash_env("mkdir -p .alembic/<repo>/repos/<dest-dir> && "
+             "wget -q -O .alembic/<repo>/repos/<destination> '<URL>'")
+
+Unpack archives at the Destination if the repo expects extracted files
+(`tar -xzf ... -C <dir>`, `unzip ...`).
+
+**Verify every download before moving on.** A silent partial download is
+worse than none — the failure surfaces much later in the validator. Confirm
+the file exists and is non-empty:
+
+    bash_env("ls -lh .alembic/<repo>/repos/<destination>")   # size > 0
+    # for HF cache, confirm the snapshot dir is populated:
+    bash_env("find .alembic/<repo>/output/.hf-cache -name '*.safetensors' -o -name '*.bin' | head")
+
+If a download fails twice for the same asset, stop retrying it, mark it
+SKIPPED in the report with the error, and continue — do not let one asset
+block the whole setup.
+
 ### Step 4 — Post-install compatibility check
 
 For each venv you created, run:
@@ -261,4 +350,16 @@ The report must contain:
 
   ## Key packages installed
   Bullet list of the main packages (name + version where known) per venv.
+
+  ## External Assets
+  Omit this section only if the exploration report listed no assets.
+  Otherwise, for each asset from the report:
+  - **<Name>** — DOWNLOADED | SKIPPED
+    - Path: where it now lives on disk (`.alembic/<repo>/repos/<dest>` or the
+      HF cache dir `.alembic/<repo>/output/.hf-cache`)
+    - Source used: the exact `hf:` / `script:` / `url:` command that fetched it
+    - If SKIPPED: the one-line reason (gated without token, too large, or the
+      download error) — the coder should default the dependent tool to SKIP.
+  If you set `HF_HOME`, state its path here so the generated server can reuse
+  the same cache.
 '''

--- a/CoScientist/alembic/instructions/explorer.py
+++ b/CoScientist/alembic/instructions/explorer.py
@@ -58,6 +58,33 @@ Record:
   - The key runtime dependencies (package names + versions if pinned)
   - The exact install command from the README, if any
 
+### Step 4c — Identify external assets (weights / datasets / databases)
+
+Many scientific repos do NOT ship their model weights, checkpoints, vocab
+files, or reference databases in git — they download them on first use or
+expect the user to fetch them manually. If the MCP server later calls repo
+code that needs one of these and it is absent, the tool fails at runtime.
+Your job here is only to DETECT and DESCRIBE these assets — the environment
+agent will actually download them from the section you write.
+
+Look for evidence of external assets (spend at most 3-4 tool calls here):
+  - HuggingFace references in code or README:
+      bash("grep -rEn 'from_pretrained|hf_hub_download|snapshot_download' <local_path> --include=*.py")
+      Note the exact repo id and revision if pinned (e.g. "org/model@a1b2c3d").
+  - Download scripts shipped by the repo (PREFER these — they place files in
+    the exact paths the repo expects):
+      search(repo_url, "**/download*")        # download.sh, download_weights.py
+      bash("grep -rEn 'wget|curl|gdown|gsutil|azcopy' <local_path> --include=*.sh --include=*.py --include=*.md")
+  - Direct URLs to .pth/.ckpt/.pt/.bin/.onnx/.h5/.tar.gz/.zip/.db weights or
+    datasets in the README or a config file.
+  - README sections titled "Download", "Pretrained models", "Checkpoints",
+    "Data", "Weights".
+
+For each asset you find, record: what it is, its type, where it comes from,
+the destination path the repo expects, and whether the core workflows need
+it. If you find NO external assets, say so explicitly — that is a valid and
+useful finding (it means the repo is self-contained).
+
 ### Step 5 — Write report
 Save your findings by calling:
     write_report(repo_url, "exploration", <content>)
@@ -90,6 +117,28 @@ The report must contain:
     packages.
   - **Install command**: the exact command from the README, or the recommended
     one you derived (e.g. `pip install -e .` or `uv pip install -r requirements.txt`).
+
+  ## External Assets
+  List every model weight / checkpoint / dataset / reference database the repo
+  needs at runtime but does NOT ship in git. Write "None — repo is
+  self-contained" if there are none. For each asset use this exact block so
+  the environment agent can act on it directly:
+
+  - **Name**: short human label (e.g. "MolScribe pretrained checkpoint")
+    - **Type**: weights | dataset | database | vocab | other
+    - **Source**: ONE of —
+        - `hf:<repo_id>@<revision>` (HuggingFace; copy the id verbatim, pin the
+          revision/commit if the code does, else use `@main`)
+        - `script:<repo-relative path>` (a download script the repo ships, e.g.
+          `script:scripts/download_weights.sh` — PREFER this when it exists)
+        - `url:<direct download URL>` (a raw file link for wget/curl)
+    - **Destination**: the path the repo expects the file(s) at, repo-relative
+      (e.g. `checkpoints/best.pth`). If unknown, write "repo default / HF cache".
+    - **Required for**: which of your usage scenarios below break without it,
+      or "optional".
+    - **Gated / size note**: mark "gated" (needs a HuggingFace token / license
+      acceptance) or an approximate size if it looks large (> ~2 GB). Otherwise
+      "public, small".
 
   ## Suggested MCP Usage Scenarios
   List up to 5 scenarios in decreasing order of usefulness. Each scenario:


### PR DESCRIPTION
Changes:
- explorer: detect external assets (HF/scripts/URLs), report them structured
- environment: Step 3c downloads assets (hf/wget/script) with HF cache + verify
- environment: Attempt 0 installs repo from PyPI (`pip install <name>`)