### PR TITLE
Fix: make MCPServer tool result JSON-serializable

### DIFF
--- a/CoScientist/tools/retrieval_tools.py
+++ b/CoScientist/tools/retrieval_tools.py
@@ -193,9 +193,21 @@ class RetrievalToolSet(BaseToolset):
             # Always release the DB connection, even if the lookup raises.
             await postgres.close()
 
+        # get_server returns None when no server matches the id — don't call
+        # model_dump on it (AttributeError), report a clean not-found instead.
+        if server is None:
+            return {
+                "status": "error",
+                "result": None,
+                "message": f"No MCP server found for server_id={server_id!r}.",
+            }
+
         return {
             "status": "success",
-            "result": server,
+            # model_dump(mode="json") so datetime/enum fields become JSON-native
+            # — a raw MCPServer (or its datetime fields) is not JSON serializable
+            # and would crash any json.dumps consumer (web ws, Opik trace, ADK state).
+            "result": server.model_dump(mode="json"),
         }
 
 

--- a/CoScientist/web/app.py
+++ b/CoScientist/web/app.py
@@ -24,6 +24,25 @@ from google.adk.workflow.utils._workflow_hitl_utils import (
 )
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _json_safe(value):
+    """Return a deeply JSON-serializable copy of ``value``.
+
+    ws.send_json() calls json.dumps() WITHOUT a ``default`` hook, so any object
+    it can't natively encode (e.g. a pydantic ``MCPServer`` nested inside a tool
+    result) raises and kills the whole event stream. Round-tripping through
+    json.dumps(default=str) coerces such leaves to strings while preserving the
+    dict/list structure the frontend expects — matching the project's existing
+    logging/graph serialisation convention.
+    """
+    try:
+        return json.loads(json.dumps(value, default=str, ensure_ascii=False))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+# ---------------------------------------------------------------------------
 # Globals
 # ---------------------------------------------------------------------------
 WEB_DIR = Path(__file__).parent
@@ -325,23 +344,18 @@ async def _handle_chat(ws: WebSocket, data: dict):
                             fc = part.function_call
                             tool_calls.append({
                                 "name": fc.name,
-                                "args": dict(fc.args) if fc.args else {},
+                                "args": _json_safe(dict(fc.args) if fc.args else {}),
                             })
                         if hasattr(part, 'function_response') and part.function_response:
                             fr = part.function_response
-                            # Safely serialise – response can be dict, str,
-                            # Pydantic model, etc.
-                            try:
-                                resp_payload = (
-                                    fr.response
-                                    if isinstance(fr.response, (dict, list, str, int, float, bool, type(None)))
-                                    else str(fr.response)
-                                )
-                            except Exception:
-                                resp_payload = str(fr.response)
+                            # Deep JSON-safe: a tool may return a dict that NESTS a
+                            # non-serializable object (e.g. a pydantic MCPServer under
+                            # "result"). A shallow isinstance(dict) check passes such a
+                            # payload straight through and then ws.send_json crashes the
+                            # whole stream — so sanitise recursively (objects -> str).
                             tool_responses.append({
                                 "name": fr.name,
-                                "response": resp_payload,
+                                "response": _json_safe(fr.response),
                             })
                     if tool_calls:
                         event_data["tool_calls"] = tool_calls


### PR DESCRIPTION
get_server_info returned a raw pydantic MCPServer object under "result". It reached json.dumps consumers (web ws.send_json, Opik trace, ADK state) unserialized and crashed the whole event stream with "Object of type MCPServer is not JSON serializable".

- retrieval_tools.get_server_info: return server.model_dump(mode="json") so datetime/enum fields become JSON-native (root cause). Guard the not-found case (get_server -> None) so we don't call model_dump on None.
- web/app.py: add _json_safe() and sanitize tool_call args / tool_response payloads recursively, so any future non-serializable tool result degrades to a string instead of killing the websocket stream (defense in depth).