### PR TITLE
Synapse v1 adapter layer for checkpoints (off by default)

### DIFF
--- a/CoScientist/a2a/server.py
+++ b/CoScientist/a2a/server.py
@@ -133,6 +133,12 @@ def make_a2a_app(
         checkpoint_plugin = CheckpointPlugin()
         plugins.insert(0, checkpoint_plugin)
 
+    if get_settings().synapse.enabled:
+        # Synapse v1: hang our steps under the platform's incoming traceparent.
+        from CoScientist.checkpoints.synapse import SynapseTracePlugin
+
+        plugins.insert(0, SynapseTracePlugin())
+
     runner = Runner(
         agent=agent,
         app_name=app_name,

--- a/CoScientist/checkpoints/api.py
+++ b/CoScientist/checkpoints/api.py
@@ -36,6 +36,12 @@ class RestoreRequest(BaseModel):
     import_stores: bool = True
 
 
+class RunRegisterRequest(BaseModel):
+    context_id: str
+    run_id: str
+    traceparent: Optional[str] = None
+
+
 def make_checkpoint_router(
     *,
     session_service=None,
@@ -64,6 +70,14 @@ def make_checkpoint_router(
     @router.get("")
     async def list_checkpoints(run_id: Optional[str] = None):
         return {"checkpoints": store.list(run_id)}
+
+    @router.post("/runs")
+    async def register_run(body: RunRegisterRequest):
+        # Synapse v1: the platform registers its run_id + traceparent for a
+        # contextId before message/send, so capture stamps the platform run_id.
+        from CoScientist.checkpoints import synapse
+        synapse.register_run(body.context_id, body.run_id, body.traceparent)
+        return {"ok": True}
 
     @router.get("/{checkpoint_id}")
     async def get_manifest(checkpoint_id: str):

--- a/CoScientist/checkpoints/capture.py
+++ b/CoScientist/checkpoints/capture.py
@@ -247,7 +247,8 @@ async def capture_checkpoint(
         external = _external_refs(raw_state)
         state = _redact(raw_state)
 
-        rid = run_key(session)
+        from CoScientist.checkpoints import synapse
+        rid = synapse.run_id_for(session.id) or run_key(session)
         manifest = CheckpointManifest(
             checkpoint_id=new_checkpoint_id(label),
             label=label,
@@ -267,6 +268,7 @@ async def capture_checkpoint(
             validator_pending=_validator_pending() if validator_pending is None else validator_pending,
             pins=collect_pins(),
         )
+        manifest.snapshot_ref = synapse.snapshot_ref_for(manifest.checkpoint_id)
 
         parts = {
             "session_events": _json_bytes(events),

--- a/CoScientist/checkpoints/capture.py
+++ b/CoScientist/checkpoints/capture.py
@@ -276,7 +276,9 @@ async def capture_checkpoint(
         }
         parts.update(_collect_store_parts())
 
-        return store.save(manifest, parts)
+        saved = store.save(manifest, parts)
+        synapse.notify_snapshot_saved(saved)
+        return saved
     except Exception:  # noqa: BLE001 — never break the run because of a snapshot
         logger.exception("checkpoint capture failed (label=%s); run continues", label)
         return None

--- a/CoScientist/checkpoints/model.py
+++ b/CoScientist/checkpoints/model.py
@@ -53,3 +53,4 @@ class CheckpointManifest(BaseModel):
     validator_pending: bool = False
     pins: Dict[str, Any] = Field(default_factory=dict)
     warnings: List[str] = Field(default_factory=list)
+    snapshot_ref: Optional[str] = None   # Synapse v1: platform-held reference to the bundle

--- a/CoScientist/checkpoints/synapse.py
+++ b/CoScientist/checkpoints/synapse.py
@@ -77,3 +77,93 @@ def notify_snapshot_saved(manifest) -> None:
         httpx.post(f"{cfg.callback_url.rstrip('/')}/points", json=body, timeout=5.0)
     except Exception as exc:  # noqa: BLE001 — never break the run
         logger.warning("synapse: snapshot-ready callback failed: %s", exc)
+
+
+# ── minimal OTel: hang our steps under the platform's traceparent ────────────
+from opentelemetry import trace as _ot_trace
+from opentelemetry.trace import (
+    NonRecordingSpan, SpanContext, TraceFlags, set_span_in_context,
+)
+
+_TRACER = None
+_OTEL_READY = False
+
+
+def setup_otel() -> None:
+    """Install an OTLP exporter once (best-effort). No-op if unconfigured."""
+    global _TRACER, _OTEL_READY
+    if _OTEL_READY:
+        return
+    _OTEL_READY = True
+    cfg = _synapse_cfg()
+    try:
+        if cfg.otlp_endpoint:
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+            provider = TracerProvider()
+            provider.add_span_processor(
+                SimpleSpanProcessor(OTLPSpanExporter(endpoint=cfg.otlp_endpoint)))
+            _ot_trace.set_tracer_provider(provider)
+        _TRACER = _ot_trace.get_tracer("coscientist.synapse")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("synapse: OTel setup failed: %s", exc)
+
+
+def _parent_ctx(traceparent: Optional[str]):
+    """W3C traceparent -> an OTel context whose current span is the remote parent."""
+    if not traceparent:
+        return None
+    try:
+        _v, trace_id, span_id, flags = traceparent.split("-")
+        sc = SpanContext(
+            trace_id=int(trace_id, 16), span_id=int(span_id, 16),
+            is_remote=True, trace_flags=TraceFlags(int(flags, 16)),
+        )
+        return set_span_in_context(NonRecordingSpan(sc))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _start_run_span(context_id: str, agent_name: str, run_id: str):
+    if _TRACER is None:
+        return None
+    ctx = _parent_ctx(traceparent_for(context_id))
+    return _TRACER.start_span(
+        "invoke_agent", context=ctx,
+        attributes={"gen_ai.operation.name": "invoke_agent",
+                    "gen_ai.agent.name": agent_name, "run_id": run_id},
+    )
+
+
+def _end_run_span(handle) -> None:
+    if handle is not None:
+        try:
+            handle.end()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+from google.adk.plugins.base_plugin import BasePlugin as _BasePlugin
+
+
+class SynapseTracePlugin(_BasePlugin):
+    """Hangs one invoke_agent span per run under the platform's traceparent."""
+
+    def __init__(self) -> None:
+        super().__init__(name="synapse_trace")
+        setup_otel()
+        self._spans: Dict[str, object] = {}
+
+    async def before_run_callback(self, *, invocation_context):
+        s = invocation_context.session
+        rid = run_id_for(s.id) or f"{s.app_name}__{s.id}"
+        self._spans[invocation_context.invocation_id] = _start_run_span(
+            s.id, invocation_context.agent.name, rid)
+        return None
+
+    async def after_run_callback(self, *, invocation_context):
+        _end_run_span(self._spans.pop(invocation_context.invocation_id, None))
+        return None

--- a/CoScientist/checkpoints/synapse.py
+++ b/CoScientist/checkpoints/synapse.py
@@ -13,6 +13,8 @@ import logging
 import threading
 from typing import Dict, Optional
 
+import httpx
+
 logger = logging.getLogger(__name__)
 
 _LOCK = threading.Lock()
@@ -51,3 +53,27 @@ def snapshot_ref_for(checkpoint_id: str) -> Optional[str]:
     if not base:
         return None
     return f"{base.rstrip('/')}/api/checkpoints/{checkpoint_id}/bundle"
+
+
+def _synapse_cfg():
+    from CoScientist.config import get_settings
+    return get_settings().synapse
+
+
+def notify_snapshot_saved(manifest) -> None:
+    """Tell the platform a snapshot is ready (best-effort). v1 §5: one call,
+    the platform records the point itself — no separate 'snapshot created' event."""
+    cfg = _synapse_cfg()
+    if not cfg.enabled or not cfg.callback_url:
+        return
+    body = {
+        "point_id": manifest.checkpoint_id,
+        "run_id": manifest.run_id,
+        "time": manifest.created_at,
+        "label": manifest.label,
+        "snapshot_ref": manifest.snapshot_ref,
+    }
+    try:
+        httpx.post(f"{cfg.callback_url.rstrip('/')}/points", json=body, timeout=5.0)
+    except Exception as exc:  # noqa: BLE001 — never break the run
+        logger.warning("synapse: snapshot-ready callback failed: %s", exc)

--- a/CoScientist/checkpoints/synapse.py
+++ b/CoScientist/checkpoints/synapse.py
@@ -1,0 +1,53 @@
+"""Synapse v1 contract bridge for the checkpoint subsystem.
+
+Off unless SYNAPSE__ENABLED. Holds a process-local registry mapping an A2A
+contextId (== ADK session id) to the platform-issued run_id + traceparent, so
+capture stamps the platform's run_id instead of the self-generated one. Also
+builds the snapshot_ref and fires the outbound "snapshot ready" callback.
+
+Every function is best-effort: a bridge failure never breaks the science run.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+_RUN_CONTEXT: Dict[str, Dict[str, Optional[str]]] = {}   # context_id -> {run_id, traceparent}
+
+
+def _bundle_base_url() -> Optional[str]:
+    from CoScientist.config import get_settings
+    return get_settings().synapse.bundle_base_url
+
+
+def register_run(context_id: str, run_id: str, traceparent: Optional[str] = None) -> None:
+    with _LOCK:
+        _RUN_CONTEXT[context_id] = {"run_id": run_id, "traceparent": traceparent}
+
+
+def run_id_for(context_id: str) -> Optional[str]:
+    with _LOCK:
+        entry = _RUN_CONTEXT.get(context_id)
+        return entry["run_id"] if entry else None
+
+
+def traceparent_for(context_id: str) -> Optional[str]:
+    with _LOCK:
+        entry = _RUN_CONTEXT.get(context_id)
+        return entry["traceparent"] if entry else None
+
+
+def clear_runs() -> None:
+    with _LOCK:
+        _RUN_CONTEXT.clear()
+
+
+def snapshot_ref_for(checkpoint_id: str) -> Optional[str]:
+    base = _bundle_base_url()
+    if not base:
+        return None
+    return f"{base.rstrip('/')}/api/checkpoints/{checkpoint_id}/bundle"

--- a/CoScientist/config/settings.py
+++ b/CoScientist/config/settings.py
@@ -252,6 +252,24 @@ class CheckpointSettings(BaseModel):
 
 
 # =========================
+# SYNAPSE v1 ADAPTER
+# =========================
+class SynapseSettings(BaseModel):
+    """Synapse platform v1 contract bridge (checkpoints/synapse.py).
+
+    OFF by default: enabling makes checkpoints report to the platform
+    (callback_url), stamps platform-issued run_ids, builds snapshot_refs from
+    bundle_base_url, and exports OTel spans to otlp_endpoint. Override via
+    SYNAPSE__ENABLED / SYNAPSE__CALLBACK_URL / SYNAPSE__BUNDLE_BASE_URL /
+    SYNAPSE__OTLP_ENDPOINT.
+    """
+    enabled: bool = False
+    callback_url: Optional[str] = None      # platform base URL for "snapshot ready"
+    bundle_base_url: Optional[str] = None    # adapter base URL used to build snapshot_ref
+    otlp_endpoint: Optional[str] = None      # OTLP HTTP collector for trace export
+
+
+# =========================
 # MAIN SETTINGS
 # =========================
 class Settings(BaseSettings):
@@ -272,6 +290,7 @@ class Settings(BaseSettings):
     mcp: MCPSettings = MCPSettings()
     research_graph: ResearchGraphSettings = ResearchGraphSettings()
     checkpoints: CheckpointSettings = CheckpointSettings()
+    synapse: SynapseSettings = SynapseSettings()
 
     model_config = SettingsConfigDict(
         env_file=".env",          

--- a/CoScientist/examples/example_config.env
+++ b/CoScientist/examples/example_config.env
@@ -219,3 +219,22 @@ FEDOTMAS_DEFAULT_MODEL= openrouter/openai/gpt-oss-120b
 OPENAI_API_KEY = 
 DOWNLOADED_PAPERS_PATH=/full/path/to/folder/for/downloaded/papers
 PROCESSED_IMG_STORAGE_PATH=ChemCoScientist/data_store/imgs-proc
+# =========================
+# CHECKPOINTS / RESEARCH GRAPH / SYNAPSE  (feat/synapse-v1-adapter)
+# =========================
+# Run-state snapshots at module boundaries (checkpoints/ package). OFF by default.
+CHECKPOINTS__ENABLED=false
+# CHECKPOINTS__DIR=./checkpoints_data
+
+# The research context graph outlives a single chat session by default (a
+# research spans many prompts). Set true so Stop / a new dialog archives + clears
+# it -> each run starts fresh (predictable checkpoints, no "continuing prior work").
+RESEARCH_GRAPH__RESET_ON_SESSION=false
+
+# Synapse v1 adapter bridge (checkpoints/synapse.py). OFF by default. When on:
+# stamps platform-issued run_id, posts a "snapshot ready" callback, builds the
+# snapshot_ref, and exports OTel spans under the platform's traceparent.
+# SYNAPSE__ENABLED=false
+# SYNAPSE__CALLBACK_URL=http://<platform-host>:<port>
+# SYNAPSE__BUNDLE_BASE_URL=http://<adapter-host>:<port>
+# SYNAPSE__OTLP_ENDPOINT=http://<collector-host>:<port>/v1/traces

--- a/CoScientist/web/templates/index.html
+++ b/CoScientist/web/templates/index.html
@@ -766,7 +766,7 @@
       currentPlannerHitlRequest = null;
       updateRoadmapModalButtons();
       addTelemetry('STOP :: user requested stop, clearing agent context');
-      addSystemMsg('⏹ Chat stopped. All agents and their context have been cleared.');
+      addSystemMsg('⏹ Прогон остановлен, диалог очищен. Сохранённые чекпоинты не затронуты — они в панели «Checkpoints» справа, откат доступен в любой момент.');
     }
 
     function clearChat() {

--- a/CoScientist/web/templates/index.html
+++ b/CoScientist/web/templates/index.html
@@ -219,6 +219,20 @@
         </div>
       </div>
 
+      <!-- Checkpoints -->
+      <div class="bg-surface-container-lowest p-4 rounded-xl border border-outline-variant/10 overflow-hidden relative">
+        <div class="absolute top-3 right-3">
+          <button onclick="refreshCheckpoints()" title="Обновить"
+            class="text-[#424656] hover:text-primary transition-colors">
+            <span class="material-symbols-outlined text-sm">refresh</span>
+          </button>
+        </div>
+        <h4 class="text-[10px] font-bold text-outline-variant uppercase mb-3 tracking-widest">Checkpoints</h4>
+        <div id="checkpoint-list" class="space-y-2 max-h-96 overflow-y-auto no-scrollbar">
+          <div class="text-outline-variant text-[9px] font-mono">Пока нет снимков</div>
+        </div>
+      </div>
+
       <!-- HITL Pending -->
       <div id="hitl-panel" class="hidden">
         <!-- Filled dynamically -->
@@ -772,8 +786,62 @@
     // =========================================================================
     // Init
     // =========================================================================
+    // ── Checkpoints panel ──────────────────────────────────────────────
+    async function refreshCheckpoints() {
+      try {
+        const r = await fetch('/api/checkpoints');
+        const d = await r.json();
+        renderCheckpoints(d.checkpoints || []);
+      } catch (e) { /* keep last render */ }
+    }
+    function renderCheckpoints(cps) {
+      const el = document.getElementById('checkpoint-list');
+      if (!el) return;
+      if (!cps.length) {
+        el.innerHTML = '<div class="text-outline-variant text-[9px] font-mono">Пока нет снимков</div>';
+        return;
+      }
+      cps.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+      el.innerHTML = cps.map(c => {
+        const t = (c.created_at || '').slice(11, 19);
+        return `
+        <div class="bg-surface-container-high/40 rounded-md p-2 border border-outline-variant/10 flex items-center justify-between gap-2">
+          <div class="min-w-0">
+            <div class="text-[10px] font-bold text-on-surface-variant truncate">${escHtml(c.label)}</div>
+            <div class="text-[8px] font-mono text-outline-variant">${t} · ${c.size_kb}KB</div>
+          </div>
+          <button onclick="restoreCheckpoint('${c.checkpoint_id}')" title="Откатиться к этой точке"
+            class="shrink-0 flex items-center gap-1 px-2 py-1 bg-primary/15 text-primary border border-primary/30 rounded hover:bg-primary/25 transition-all text-[9px] font-bold uppercase tracking-widest">
+            <span class="material-symbols-outlined text-[13px]">restore</span> Откат
+          </button>
+        </div>`;
+      }).join('');
+    }
+    async function restoreCheckpoint(id) {
+      addSystemMsg('Восстановление из точки …' + id.slice(-8));
+      try {
+        const r = await fetch('/api/checkpoints/' + encodeURIComponent(id) + '/restore', { method: 'POST' });
+        const d = await r.json();
+        if (r.ok && d.context_id) {
+          addSystemMsg('✓ Откат выполнен — новый прогон …' + d.context_id.slice(-8) +
+            ' (' + d.event_count + ' событий). ' + (d.resume_hint || ''));
+        } else {
+          const why = d.detail ? (typeof d.detail === 'string' ? d.detail : JSON.stringify(d.detail)) : ('HTTP ' + r.status);
+          addSystemMsg('✗ Откат отклонён: ' + why);
+        }
+      } catch (e) {
+        addSystemMsg('✗ Ошибка отката: ' + e);
+      }
+      refreshCheckpoints();
+    }
+    function initCheckpoints() {
+      refreshCheckpoints();
+      setInterval(refreshCheckpoints, 5000);
+    }
+
     initAgentNav();
     connect();
+    initCheckpoints();
 
     // Keep-alive ping
     setInterval(() => { if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'ping' })); }, 30000);

--- a/CoScientist/web/templates/index.html
+++ b/CoScientist/web/templates/index.html
@@ -787,21 +787,29 @@
     // Init
     // =========================================================================
     // ── Checkpoints panel ──────────────────────────────────────────────
+    let _cpSig = null;
     async function refreshCheckpoints() {
       try {
-        const r = await fetch('/api/checkpoints');
+        // no-store + cache-bust: the endpoint sends no cache headers, so a plain
+        // fetch can be served stale by the browser and the list would freeze.
+        const r = await fetch('/api/checkpoints?_=' + Date.now(), { cache: 'no-store' });
+        if (!r.ok) return;
         const d = await r.json();
         renderCheckpoints(d.checkpoints || []);
-      } catch (e) { /* keep last render */ }
+      } catch (e) { console.error('checkpoints refresh failed', e); }
     }
     function renderCheckpoints(cps) {
       const el = document.getElementById('checkpoint-list');
       if (!el) return;
+      cps.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+      // only touch the DOM when the set actually changed → no 5s flicker / scroll jump
+      const sig = cps.map(c => c.checkpoint_id).join('|');
+      if (sig === _cpSig) return;
+      _cpSig = sig;
       if (!cps.length) {
         el.innerHTML = '<div class="text-outline-variant text-[9px] font-mono">Пока нет снимков</div>';
         return;
       }
-      cps.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
       el.innerHTML = cps.map(c => {
         const t = (c.created_at || '').slice(11, 19);
         return `

--- a/docs/superpowers/plans/2026-07-29-synapse-v1-adapter.md
+++ b/docs/superpowers/plans/2026-07-29-synapse-v1-adapter.md
@@ -1,0 +1,833 @@
+# Synapse v1 Adapter Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CoScientist's existing checkpoint subsystem speak the Synapse v1 core contract — platform-issued run_id, a "snapshot ready" callback with a stable snapshot_ref, platform-driven restore, minimal OTel traceparent stitching, and a single adapter endpoint — verified end-to-end against a local mock platform.
+
+**Architecture:** A thin bridge module `checkpoints/synapse.py` holds a process-local run registry (context_id → run_id/traceparent), builds the snapshot_ref, and fires the outbound callback; the existing capture/restore code is reused unchanged except for reading run_id from the registry. A `scripts/mock_synapse.py` stand-in issues run_ids, receives callbacks, and drives restore. Everything is OFF by default (`SYNAPSE__ENABLED=false`).
+
+**Tech Stack:** Python 3.12.11, FastAPI (already the A2A app), google-adk 2.3.0 plugins, opentelemetry-sdk (already in venv), httpx (already a dep), pytest.
+
+## Global Constraints
+
+- Python **3.12.11**; run everything with the repo venv: `/Users/kiriill/Documents/Python/CoScientist/.venv/bin/python`.
+- Work in the worktree `.../scratchpad/cp2` on branch `feat/synapse-v1-adapter`; set `PYTHONPATH` to that worktree root when running.
+- **OFF by default:** with `SYNAPSE__ENABLED=false` (the default) behaviour is byte-identical to today. Every new code path is gated on it.
+- **Best-effort, never break the run:** every bridge call is wrapped in try/except and logs on failure — a snapshot/callback/trace failure must never fail the science run (same doctrine as `capture.py`).
+- **Do not break** `tests/e2e_checkpoint_a2a.py` (bare restore); it must stay green.
+- Tests use the scripted deterministic agent pattern from `tests/e2e_checkpoint_a2a.py` — **no LLM, no VPN, no network** beyond localhost.
+- Reuse, don't rewrite: restore (`checkpoints/restore.py`) and the store (`checkpoints/store.py`) are untouched.
+
+---
+
+### Task 1: SynapseSettings config
+
+**Files:**
+- Modify: `CoScientist/config/settings.py:243-274`
+- Test: `tests/test_synapse_bridge.py`
+
+**Interfaces:**
+- Produces: `settings.synapse.enabled: bool`, `settings.synapse.callback_url: str | None`, `settings.synapse.bundle_base_url: str | None`, `settings.synapse.otlp_endpoint: str | None`. Env keys: `SYNAPSE__ENABLED`, `SYNAPSE__CALLBACK_URL`, `SYNAPSE__BUNDLE_BASE_URL`, `SYNAPSE__OTLP_ENDPOINT`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_synapse_bridge.py
+import os
+
+def test_synapse_settings_default_off(monkeypatch):
+    monkeypatch.delenv("SYNAPSE__ENABLED", raising=False)
+    from CoScientist.config.settings import Settings
+    s = Settings()
+    assert s.synapse.enabled is False
+    assert s.synapse.callback_url is None
+    assert s.synapse.bundle_base_url is None
+    assert s.synapse.otlp_endpoint is None
+
+def test_synapse_settings_from_env(monkeypatch):
+    monkeypatch.setenv("SYNAPSE__ENABLED", "true")
+    monkeypatch.setenv("SYNAPSE__CALLBACK_URL", "http://localhost:9999")
+    from CoScientist.config.settings import Settings
+    s = Settings()
+    assert s.synapse.enabled is True
+    assert s.synapse.callback_url == "http://localhost:9999"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k synapse_settings -v`
+Expected: FAIL — `Settings` has no attribute `synapse`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add after `CheckpointSettings` (settings.py:251), before `# MAIN SETTINGS`:
+
+```python
+# =========================
+# SYNAPSE v1 ADAPTER
+# =========================
+class SynapseSettings(BaseModel):
+    """Synapse platform v1 contract bridge (checkpoints/synapse.py).
+
+    OFF by default: enabling makes checkpoints report to the platform
+    (callback_url), stamps platform-issued run_ids, builds snapshot_refs from
+    bundle_base_url, and exports OTel spans to otlp_endpoint. Override via
+    SYNAPSE__ENABLED / SYNAPSE__CALLBACK_URL / SYNAPSE__BUNDLE_BASE_URL /
+    SYNAPSE__OTLP_ENDPOINT.
+    """
+    enabled: bool = False
+    callback_url: Optional[str] = None      # platform base URL for "snapshot ready"
+    bundle_base_url: Optional[str] = None    # adapter base URL used to build snapshot_ref
+    otlp_endpoint: Optional[str] = None      # OTLP HTTP collector for trace export
+```
+
+Add to the `Settings` class body after line 274 (`checkpoints: ...`):
+
+```python
+    synapse: SynapseSettings = SynapseSettings()
+```
+
+(`Optional` is already imported in settings.py.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k synapse_settings -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CoScientist/config/settings.py tests/test_synapse_bridge.py
+git commit -m "feat(synapse): add SynapseSettings (off by default)"
+```
+
+---
+
+### Task 2: Bridge core — run registry + snapshot_ref
+
+**Files:**
+- Create: `CoScientist/checkpoints/synapse.py`
+- Test: `tests/test_synapse_bridge.py`
+
+**Interfaces:**
+- Consumes: `settings.synapse.bundle_base_url` (Task 1).
+- Produces:
+  - `register_run(context_id: str, run_id: str, traceparent: str | None = None) -> None`
+  - `run_id_for(context_id: str) -> str | None`
+  - `traceparent_for(context_id: str) -> str | None`
+  - `snapshot_ref_for(checkpoint_id: str) -> str | None`
+  - `clear_runs() -> None`  (test helper)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_synapse_bridge.py  (append)
+def test_run_registry_roundtrip():
+    from CoScientist.checkpoints import synapse
+    synapse.clear_runs()
+    synapse.register_run("ctx-1", "run-1a2b", "00-abc-def-01")
+    assert synapse.run_id_for("ctx-1") == "run-1a2b"
+    assert synapse.traceparent_for("ctx-1") == "00-abc-def-01"
+    assert synapse.run_id_for("unknown") is None
+
+def test_snapshot_ref_build(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    monkeypatch.setattr(synapse, "_bundle_base_url", lambda: "http://host:8100")
+    assert synapse.snapshot_ref_for("ckpt_X") == "http://host:8100/api/checkpoints/ckpt_X/bundle"
+
+def test_snapshot_ref_none_when_unconfigured(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    monkeypatch.setattr(synapse, "_bundle_base_url", lambda: None)
+    assert synapse.snapshot_ref_for("ckpt_X") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k "registry or snapshot_ref" -v`
+Expected: FAIL — `No module named 'CoScientist.checkpoints.synapse'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# CoScientist/checkpoints/synapse.py
+"""Synapse v1 contract bridge for the checkpoint subsystem.
+
+Off unless SYNAPSE__ENABLED. Holds a process-local registry mapping an A2A
+contextId (== ADK session id) to the platform-issued run_id + traceparent, so
+capture stamps the platform's run_id instead of the self-generated one. Also
+builds the snapshot_ref and fires the outbound "snapshot ready" callback.
+
+Every function is best-effort: a bridge failure never breaks the science run.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+_RUN_CONTEXT: Dict[str, Dict[str, Optional[str]]] = {}   # context_id -> {run_id, traceparent}
+
+
+def _bundle_base_url() -> Optional[str]:
+    from CoScientist.config import get_settings
+    return get_settings().synapse.bundle_base_url
+
+
+def register_run(context_id: str, run_id: str, traceparent: Optional[str] = None) -> None:
+    with _LOCK:
+        _RUN_CONTEXT[context_id] = {"run_id": run_id, "traceparent": traceparent}
+
+
+def run_id_for(context_id: str) -> Optional[str]:
+    with _LOCK:
+        entry = _RUN_CONTEXT.get(context_id)
+        return entry["run_id"] if entry else None
+
+
+def traceparent_for(context_id: str) -> Optional[str]:
+    with _LOCK:
+        entry = _RUN_CONTEXT.get(context_id)
+        return entry["traceparent"] if entry else None
+
+
+def clear_runs() -> None:
+    with _LOCK:
+        _RUN_CONTEXT.clear()
+
+
+def snapshot_ref_for(checkpoint_id: str) -> Optional[str]:
+    base = _bundle_base_url()
+    if not base:
+        return None
+    return f"{base.rstrip('/')}/api/checkpoints/{checkpoint_id}/bundle"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k "registry or snapshot_ref" -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CoScientist/checkpoints/synapse.py tests/test_synapse_bridge.py
+git commit -m "feat(synapse): run registry + snapshot_ref builder"
+```
+
+---
+
+### Task 3: Platform run_id + snapshot_ref in the manifest
+
+**Files:**
+- Modify: `CoScientist/checkpoints/model.py:37-55`
+- Modify: `CoScientist/checkpoints/capture.py:250-269`
+- Test: `tests/test_synapse_bridge.py`
+
+**Interfaces:**
+- Consumes: `synapse.run_id_for` / `synapse.snapshot_ref_for` (Task 2).
+- Produces: `CheckpointManifest.snapshot_ref: Optional[str]`; `capture_checkpoint(...)` stamps platform run_id when registered.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_synapse_bridge.py  (append)
+import asyncio, tempfile
+from types import SimpleNamespace
+
+class _FakeSession:
+    def __init__(self, sid): self.app_name="orchestrator"; self.user_id="u"; self.id=sid; self.events=[]; self.state={}
+
+def test_capture_uses_platform_run_id(monkeypatch):
+    from CoScientist.checkpoints import synapse, capture
+    from CoScientist.checkpoints.store import LocalZipStore
+    synapse.clear_runs()
+    synapse.register_run("ctx-9", "run-PLATFORM", None)
+    monkeypatch.setattr(synapse, "_bundle_base_url", lambda: "http://host:8100")
+    store = LocalZipStore(tempfile.mkdtemp())
+    m = asyncio.run(capture.capture_checkpoint(
+        session=_FakeSession("ctx-9"), label="T1_after_literature_review", store=store))
+    assert m is not None
+    assert m.run_id == "run-PLATFORM"
+    assert m.snapshot_ref == f"http://host:8100/api/checkpoints/{m.checkpoint_id}/bundle"
+
+def test_capture_falls_back_to_run_key(monkeypatch):
+    from CoScientist.checkpoints import synapse, capture
+    from CoScientist.checkpoints.store import LocalZipStore
+    synapse.clear_runs()  # nothing registered
+    store = LocalZipStore(tempfile.mkdtemp())
+    m = asyncio.run(capture.capture_checkpoint(
+        session=_FakeSession("ctx-none"), label="T5_invocation_end", store=store))
+    assert m.run_id == "orchestrator__ctx-none"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k capture -v`
+Expected: FAIL — run_id is `orchestrator__ctx-9` (fallback) and `snapshot_ref` attribute missing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `model.py`, add to `CheckpointManifest` (after `warnings`, line 55):
+
+```python
+    snapshot_ref: Optional[str] = None   # Synapse v1: platform-held reference to the bundle
+```
+
+In `capture.py`, replace line 250 (`rid = run_key(session)`) with:
+
+```python
+        from CoScientist.checkpoints import synapse
+        rid = synapse.run_id_for(session.id) or run_key(session)
+```
+
+In `capture.py`, after the `manifest = CheckpointManifest(...)` block (after line 269), before `parts = {...}`:
+
+```python
+        manifest.snapshot_ref = synapse.snapshot_ref_for(manifest.checkpoint_id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k capture -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CoScientist/checkpoints/model.py CoScientist/checkpoints/capture.py tests/test_synapse_bridge.py
+git commit -m "feat(synapse): stamp platform run_id + snapshot_ref on the manifest"
+```
+
+---
+
+### Task 4: Outbound "snapshot ready" callback
+
+**Files:**
+- Modify: `CoScientist/checkpoints/synapse.py`
+- Modify: `CoScientist/checkpoints/capture.py:277` (after `store.save`)
+- Test: `tests/test_synapse_bridge.py`
+
+**Interfaces:**
+- Consumes: `settings.synapse.enabled`, `settings.synapse.callback_url`; `CheckpointManifest` (Task 3).
+- Produces: `notify_snapshot_saved(manifest: CheckpointManifest) -> None` — best-effort `POST {callback_url}/points`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_synapse_bridge.py  (append)
+def test_notify_posts_point(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    from CoScientist.checkpoints.model import CheckpointManifest, SessionRef
+    captured = {}
+    def fake_post(url, json, timeout):
+        captured["url"] = url; captured["body"] = json
+        class R: status_code = 200
+        return R()
+    monkeypatch.setattr(synapse, "_synapse_cfg", lambda: SimpleNamespace(enabled=True, callback_url="http://plat:9000"))
+    monkeypatch.setattr(synapse.httpx, "post", fake_post)
+    m = CheckpointManifest(checkpoint_id="ckpt_X", label="T1_after_literature_review",
+        run_id="run-1", created_at="t", session=SessionRef(app_name="a", user_id="u", session_id="s"),
+        snapshot_ref="http://host/api/checkpoints/ckpt_X/bundle")
+    synapse.notify_snapshot_saved(m)
+    assert captured["url"] == "http://plat:9000/points"
+    assert captured["body"]["point_id"] == "ckpt_X"
+    assert captured["body"]["run_id"] == "run-1"
+    assert captured["body"]["label"] == "T1_after_literature_review"
+    assert captured["body"]["snapshot_ref"] == "http://host/api/checkpoints/ckpt_X/bundle"
+
+def test_notify_noop_when_disabled(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    from CoScientist.checkpoints.model import CheckpointManifest, SessionRef
+    monkeypatch.setattr(synapse, "_synapse_cfg", lambda: SimpleNamespace(enabled=False, callback_url=None))
+    called = {"n": 0}
+    monkeypatch.setattr(synapse.httpx, "post", lambda *a, **k: called.__setitem__("n", called["n"]+1))
+    m = CheckpointManifest(checkpoint_id="c", label="L", run_id="r", created_at="t",
+        session=SessionRef(app_name="a", user_id="u", session_id="s"))
+    synapse.notify_snapshot_saved(m)
+    assert called["n"] == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k notify -v`
+Expected: FAIL — `synapse` has no `httpx`/`notify_snapshot_saved`/`_synapse_cfg`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `synapse.py`, add `import httpx` at the top and:
+
+```python
+def _synapse_cfg():
+    from CoScientist.config import get_settings
+    return get_settings().synapse
+
+
+def notify_snapshot_saved(manifest) -> None:
+    """Tell the platform a snapshot is ready (best-effort). v1 §5: one call,
+    the platform records the point itself — no separate 'snapshot created' event."""
+    cfg = _synapse_cfg()
+    if not cfg.enabled or not cfg.callback_url:
+        return
+    body = {
+        "point_id": manifest.checkpoint_id,
+        "run_id": manifest.run_id,
+        "time": manifest.created_at,
+        "label": manifest.label,
+        "snapshot_ref": manifest.snapshot_ref,
+    }
+    try:
+        httpx.post(f"{cfg.callback_url.rstrip('/')}/points", json=body, timeout=5.0)
+    except Exception as exc:  # noqa: BLE001 — never break the run
+        logger.warning("synapse: snapshot-ready callback failed: %s", exc)
+```
+
+In `capture.py`, change the save line (line 277) from `return store.save(manifest, parts)` to:
+
+```python
+        saved = store.save(manifest, parts)
+        synapse.notify_snapshot_saved(saved)
+        return saved
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k notify -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CoScientist/checkpoints/synapse.py CoScientist/checkpoints/capture.py tests/test_synapse_bridge.py
+git commit -m "feat(synapse): outbound snapshot-ready callback"
+```
+
+---
+
+### Task 5: `POST /api/runs` — platform registers a run
+
+**Files:**
+- Modify: `CoScientist/checkpoints/api.py:60-75` (add route inside `make_checkpoint_router`)
+- Test: `tests/test_synapse_bridge.py`
+
+**Interfaces:**
+- Consumes: `synapse.register_run` (Task 2).
+- Produces: route `POST /api/checkpoints/runs` with body `{context_id, run_id, traceparent?}` → registers the run; returns `{"ok": True}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_synapse_bridge.py  (append)
+def test_runs_endpoint_registers(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from CoScientist.checkpoints.api import make_checkpoint_router
+    from CoScientist.checkpoints import synapse
+    from CoScientist.checkpoints.store import LocalZipStore
+    synapse.clear_runs()
+    app = FastAPI()
+    app.include_router(make_checkpoint_router(
+        session_service=object(), app_name="orchestrator", store=LocalZipStore(tempfile.mkdtemp())))
+    c = TestClient(app)
+    r = c.post("/api/checkpoints/runs",
+               json={"context_id": "ctx-77", "run_id": "run-77", "traceparent": "00-t-s-01"})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert synapse.run_id_for("ctx-77") == "run-77"
+    assert synapse.traceparent_for("ctx-77") == "00-t-s-01"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k runs_endpoint -v`
+Expected: FAIL — 404 (route not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `api.py`, add a request model near `RestoreRequest` (line 41):
+
+```python
+class RunRegisterRequest(BaseModel):
+    context_id: str
+    run_id: str
+    traceparent: Optional[str] = None
+```
+
+Inside `make_checkpoint_router`, alongside the other routes (after the `list_checkpoints` route, ~line 66):
+
+```python
+    @router.post("/runs")
+    async def register_run(body: RunRegisterRequest):
+        from CoScientist.checkpoints import synapse
+        synapse.register_run(body.context_id, body.run_id, body.traceparent)
+        return {"ok": True}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k runs_endpoint -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CoScientist/checkpoints/api.py tests/test_synapse_bridge.py
+git commit -m "feat(synapse): POST /api/checkpoints/runs registers platform run_id + traceparent"
+```
+
+---
+
+### Task 6: OTel minimal — traceparent stitching + OTLP export
+
+**Files:**
+- Modify: `CoScientist/checkpoints/synapse.py`
+- Modify: `CoScientist/a2a/server.py:128-134` (register the trace plugin when synapse enabled)
+- Test: `tests/test_synapse_bridge.py`
+
+**Interfaces:**
+- Consumes: `traceparent_for` (Task 2), `settings.synapse` (Task 1).
+- Produces:
+  - `setup_otel() -> None` — idempotent; installs a TracerProvider with OTLP exporter (or no-op if unconfigured).
+  - `SynapseTracePlugin` (google-adk `BasePlugin`): `before_run_callback` starts an `invoke_agent` span parented on the incoming traceparent; `after_run_callback` ends it.
+  - `_start_run_span(context_id, agent_name, run_id)` / `_end_run_span(handle)` — used by the plugin and directly testable.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_synapse_bridge.py  (append)
+def test_otel_span_parents_on_traceparent():
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    from CoScientist.checkpoints import synapse
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)      # test-local provider
+    synapse._TRACER = provider.get_tracer("test")
+
+    synapse.clear_runs()
+    tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+    synapse.register_run("ctx-tr", "run-tr", tp)
+    h = synapse._start_run_span("ctx-tr", "ScriptedOrchestrator", "run-tr")
+    synapse._end_run_span(h)
+
+    spans = exporter.get_finished_spans()
+    assert any(s.name == "invoke_agent" for s in spans)
+    inv = next(s for s in spans if s.name == "invoke_agent")
+    assert format(inv.context.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+    assert inv.attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert inv.attributes["gen_ai.agent.name"] == "ScriptedOrchestrator"
+    assert inv.attributes["run_id"] == "run-tr"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k otel -v`
+Expected: FAIL — `synapse` has no `_start_run_span` / `_TRACER`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `synapse.py`:
+
+```python
+from opentelemetry import trace as _ot_trace
+from opentelemetry.trace import (
+    SpanContext, TraceFlags, NonRecordingSpan, set_span_in_context,
+)
+
+_TRACER = None
+_OTEL_READY = False
+
+
+def setup_otel() -> None:
+    """Install an OTLP exporter once (best-effort). No-op if unconfigured."""
+    global _TRACER, _OTEL_READY
+    if _OTEL_READY:
+        return
+    _OTEL_READY = True
+    cfg = _synapse_cfg()
+    try:
+        if cfg.otlp_endpoint:
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            provider = TracerProvider()
+            provider.add_span_processor(
+                SimpleSpanProcessor(OTLPSpanExporter(endpoint=cfg.otlp_endpoint)))
+            _ot_trace.set_tracer_provider(provider)
+        _TRACER = _ot_trace.get_tracer("coscientist.synapse")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("synapse: OTel setup failed: %s", exc)
+
+
+def _parent_ctx(traceparent: Optional[str]):
+    """W3C traceparent -> an OTel context whose current span is the remote parent."""
+    if not traceparent:
+        return None
+    try:
+        _v, trace_id, span_id, flags = traceparent.split("-")
+        sc = SpanContext(
+            trace_id=int(trace_id, 16), span_id=int(span_id, 16),
+            is_remote=True, trace_flags=TraceFlags(int(flags, 16)),
+        )
+        return set_span_in_context(NonRecordingSpan(sc))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _start_run_span(context_id: str, agent_name: str, run_id: str):
+    if _TRACER is None:
+        return None
+    ctx = _parent_ctx(traceparent_for(context_id))
+    span = _TRACER.start_span(
+        "invoke_agent", context=ctx,
+        attributes={"gen_ai.operation.name": "invoke_agent",
+                    "gen_ai.agent.name": agent_name, "run_id": run_id},
+    )
+    return span
+
+
+def _end_run_span(handle) -> None:
+    if handle is not None:
+        try:
+            handle.end()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+from google.adk.plugins.base_plugin import BasePlugin as _BasePlugin
+
+
+class SynapseTracePlugin(_BasePlugin):
+    """Hangs one invoke_agent span per run under the platform's traceparent."""
+
+    def __init__(self) -> None:
+        super().__init__(name="synapse_trace")
+        setup_otel()
+        self._spans = {}
+
+    async def before_run_callback(self, *, invocation_context):
+        s = invocation_context.session
+        rid = run_id_for(s.id) or f"{s.app_name}__{s.id}"
+        self._spans[invocation_context.invocation_id] = _start_run_span(
+            s.id, invocation_context.agent.name, rid)
+        return None
+
+    async def after_run_callback(self, *, invocation_context):
+        _end_run_span(self._spans.pop(invocation_context.invocation_id, None))
+        return None
+```
+
+In `a2a/server.py`, after the checkpoint-plugin block (line 134), add:
+
+```python
+    if get_settings().synapse.enabled:
+        from CoScientist.checkpoints.synapse import SynapseTracePlugin
+        plugins.insert(0, SynapseTracePlugin())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -k otel -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CoScientist/checkpoints/synapse.py CoScientist/a2a/server.py tests/test_synapse_bridge.py
+git commit -m "feat(synapse): minimal OTel — invoke_agent span stitched under platform traceparent"
+```
+
+---
+
+### Task 7: Mock Synapse platform
+
+**Files:**
+- Create: `scripts/mock_synapse.py`
+- Test: covered by the e2e in Task 8 (this is a harness, not production code).
+
+**Interfaces:**
+- Produces a runnable FastAPI app + helpers:
+  - `POST /points` — records incoming "snapshot ready" callbacks into an in-memory list.
+  - `GET /points` — returns the recorded points (for assertions).
+  - `issue_run() -> tuple[str, str]` — returns `(run_id, traceparent)` with a fresh W3C traceparent.
+  - CLI `python scripts/mock_synapse.py --port 9100` runs the receiver.
+
+- [ ] **Step 1: Write the mock (no separate unit test; exercised in Task 8)**
+
+```python
+# scripts/mock_synapse.py
+"""Local stand-in for the Synapse platform — exercises the v1 adapter contract.
+
+Receives "snapshot ready" callbacks (POST /points), and provides helpers to
+issue a platform run_id + W3C traceparent. Real Synapse replaces this later.
+"""
+from __future__ import annotations
+
+import argparse
+import secrets
+
+from fastapi import FastAPI, Request
+
+_POINTS: list[dict] = []
+
+app = FastAPI()
+
+
+@app.post("/points")
+async def receive_point(request: Request):
+    _POINTS.append(await request.json())
+    return {"ok": True}
+
+
+@app.get("/points")
+async def list_points():
+    return {"points": _POINTS}
+
+
+def issue_run() -> tuple[str, str]:
+    run_id = f"run-{secrets.token_hex(3)}"
+    trace_id = secrets.token_hex(16)
+    span_id = secrets.token_hex(8)
+    traceparent = f"00-{trace_id}-{span_id}-01"
+    return run_id, traceparent
+
+
+if __name__ == "__main__":
+    import uvicorn
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=9100)
+    args = p.parse_args()
+    uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="warning")
+```
+
+- [ ] **Step 2: Sanity-run the mock imports**
+
+Run: `.venv/bin/python -c "import scripts.mock_synapse as m; print(m.issue_run())"`
+Expected: prints a `('run-xxxxxx', '00-...-...-01')` tuple.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/mock_synapse.py
+git commit -m "feat(synapse): local mock platform (callback receiver + run issuer)"
+```
+
+---
+
+### Task 8: End-to-end through the mock (the integration proof)
+
+**Files:**
+- Create: `tests/e2e_synapse_v1.py`
+- Test: itself (runnable e2e, patterned on `tests/e2e_checkpoint_a2a.py`).
+
+**Interfaces:**
+- Consumes: everything above; the scripted-agent + subprocess-server harness from `tests/e2e_checkpoint_a2a.py`.
+
+**Scenario:** mock issues run_id+traceparent → `POST /api/checkpoints/runs` on the adapter → A2A `message/send` (scripted agent, contextId = the registered ctx) → adapter auto-saves checkpoints stamped with the platform run_id, POSTs "snapshot ready" to the mock → assert the mock received a point whose `run_id` == the issued one and whose `snapshot_ref` resolves via `GET …/bundle` → `POST …/{point_id}/restore` (platform-driven) → new contextId; assert restored state.
+
+- [ ] **Step 1: Write the e2e**
+
+Copy the server/scripted-agent + client helpers from `tests/e2e_checkpoint_a2a.py` (scripted `ScriptedOrchestrator`, `make_a2a_app`, `a2a_send`, `wait_ready`, `spawn_server`, `kill`, `_http`). Set the adapter server env to enable the bridge:
+
+```python
+def spawn_server(ckpt_dir: str, mock_port: int) -> subprocess.Popen:
+    env = {**os.environ,
+           "CHECKPOINTS__ENABLED": "1", "CHECKPOINTS__DIR": ckpt_dir,
+           "SYNAPSE__ENABLED": "1",
+           "SYNAPSE__CALLBACK_URL": f"http://127.0.0.1:{mock_port}",
+           "SYNAPSE__BUNDLE_BASE_URL": f"http://127.0.0.1:{PORT}",
+           "A2A_DISABLE_OPIK": "1", "LOG_AGENT_EVENTS": "0"}
+    return subprocess.Popen([sys.executable, str(Path(__file__).resolve()), "--serve"],
+                            cwd=REPO_ROOT, env=env,
+                            stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+```
+
+Orchestration body:
+
+```python
+def main() -> None:
+    import uvicorn, threading
+    from scripts.mock_synapse import app as mock_app, _POINTS, issue_run
+    mock_port = 9100
+    threading.Thread(target=lambda: uvicorn.run(mock_app, host="127.0.0.1",
+                     port=mock_port, log_level="warning"), daemon=True).start()
+    time.sleep(1.5)
+
+    ckpt_dir = tempfile.mkdtemp(prefix="synapse_e2e_")
+    server = spawn_server(ckpt_dir, mock_port); wait_ready(server)
+    run_id, traceparent = issue_run()
+    ctx = "syn-ctx-1"
+
+    _http("POST", f"{BASE}/api/checkpoints/runs",
+          {"context_id": ctx, "run_id": run_id, "traceparent": traceparent})
+    a2a_send("start the literature phase for GSK3B", context_id=ctx)
+
+    points = _http("GET", f"http://127.0.0.1:{mock_port}/points")["points"]
+    ok("platform received a snapshot-ready callback", len(points) >= 1)
+    ok("point carries the PLATFORM run_id", all(p["run_id"] == run_id for p in points),
+       f"{[p['run_id'] for p in points]} vs {run_id}")
+    ref = points[0]["snapshot_ref"]
+    ok("snapshot_ref points at the adapter bundle URL",
+       ref and ref.startswith(f"{BASE}/api/checkpoints/") and ref.endswith("/bundle"))
+
+    listing = _http("GET", f"{BASE}/api/checkpoints?run_id={run_id}")["checkpoints"]
+    ok("adapter lists only this run's points (single endpoint)",
+       listing and all(c["run_id"] == run_id for c in listing))
+
+    pid = points[0]["point_id"]
+    restored = _http("POST", f"{BASE}/api/checkpoints/{pid}/restore", {})
+    ok("platform-driven restore returns a new contextId", bool(restored.get("context_id")))
+    kill(server)
+    print("\n[e2e] ALL SYNAPSE CHECKS PASSED")
+```
+
+Add the `--serve` / `main()` dispatch and an `ok(name, cond, detail="")` helper identical to `e2e_checkpoint_a2a.py`.
+
+- [ ] **Step 2: Run it**
+
+Run: `cd <cp2 worktree> && PYTHONPATH=. A2A_DISABLE_OPIK=1 .venv/bin/python tests/e2e_synapse_v1.py`
+Expected: `[e2e] ALL SYNAPSE CHECKS PASSED` with every `[PASS]`.
+
+- [ ] **Step 3: Confirm the bare-restore e2e still passes**
+
+Run: `PYTHONPATH=. A2A_DISABLE_OPIK=1 .venv/bin/python tests/e2e_checkpoint_a2a.py`
+Expected: `[e2e] ALL CHECKS PASSED` (no regression).
+
+- [ ] **Step 4: Run the unit suite**
+
+Run: `.venv/bin/python -m pytest tests/test_synapse_bridge.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e_synapse_v1.py
+git commit -m "test(synapse): e2e — platform run_id, snapshot-ready callback, single-endpoint list, platform-driven restore"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Single adapter endpoint → Task 8 asserts list filtered by the platform run_id (served by one agent). ✅
+- (1) platform run_id → Tasks 2,3,5. ✅
+- (2) snapshot-ready callback → Task 4. ✅
+- (3) stable snapshot_ref → Tasks 2,3 (`…/bundle` URL). ✅
+- (4) platform-initiated restore → Task 8 (mock drives `POST …/restore`; reuses existing endpoint). ✅
+- (5) OTel minimal (traceparent + 3-name/attrs, OTLP export) → Task 6. ✅
+- Mock platform → Task 7. ✅
+- Off-by-default / no regression → gating in every task; Task 8 Step 3 guards `e2e_checkpoint_a2a.py`. ✅
+
+**2. Placeholder scan:** none — every code step has concrete code.
+
+**3. Type consistency:** `register_run/run_id_for/traceparent_for/snapshot_ref_for/notify_snapshot_saved/_start_run_span/_end_run_span/setup_otel` are named identically across Tasks 2/3/4/5/6/8; `RunRegisterRequest` fields (context_id, run_id, traceparent) match the mock's `issue_run` + the e2e POST body; callback body keys (point_id, run_id, time, label, snapshot_ref) match Task 4 impl and Task 8 assertions.
+
+## Notes / deferred (from spec non-goals)
+- `replay` (strict/fresh), a dedicated `/fork` endpoint, and full GenAI attribute coverage are **out of scope** (v1 doesn't require them).
+- Adjacent gap (not this plan): A2A-mode `input-required` reaching the external endpoint (HITL handler not swapped on A2A servers).

--- a/docs/superpowers/specs/2026-07-27-synapse-v1-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-27-synapse-v1-adapter-design.md
@@ -1,0 +1,141 @@
+# Synapse Contracts v1 — adapter layer for CoScientist checkpoints
+
+**Date:** 2026-07-27
+**Status:** Design approved, ready for implementation plan
+**Branch:** `feat/synapse-v1-adapter` (off `feat/checkpoints` @ `7f48e2d`)
+
+## Context
+
+Synapse published a trial "core contract v1" for how an external MAS plugs into the
+platform (`SynapseNmas-contracts-v1`, simplified from the earlier `SynapseNmas.md`).
+This session verified that CoScientist's existing checkpoint subsystem already
+realizes almost the whole v1 checkpoint model: snapshots save on module boundaries,
+the snapshot stays on the MAS side (local zip store), and restore = a new run
+rehydrated from the bundle over A2A (proven end-to-end: kill → fresh process →
+`POST /restore` → continue via `message/send`).
+
+This spec closes the gaps between what exists and v1: five plumbing items plus the
+structural "one adapter endpoint" requirement. There is **no live Synapse platform**
+to integrate against, so we build the adapter side of the contract **and** a small
+local mock platform that exercises it end-to-end (the same way we drove the restore
+demo this session). Later the mock is swapped for the real Synapse.
+
+## Goals (the 6 items)
+
+1. **Platform-issued `run_id`** (and incoming `traceparent`) instead of a self-generated id.
+2. **Adapter → platform "snapshot ready"** outbound notification with a snapshot reference.
+3. **Stable `snapshot_ref`** the platform can store and hand back (snapshot stays with the MAS).
+4. **Platform-initiated restore** ("continue from `point_id`") driving a new run.
+5. **OTel minimal:** accept `traceparent`, hang our steps (`invoke_agent`/`execute_tool`/`chat`
+   + core attributes) under the platform's trace, export via OTLP.
+6. **One adapter endpoint / one run / one set of points** for the whole MAS.
+
+## Non-goals
+
+- Deterministic `replay` (strict/fresh) — not in v1; needs the platform journal.
+- Full GenAI semantic-convention coverage (all attributes, token/cost accounting) — minimal only.
+- A dedicated `/fork` endpoint or a branch-tree UI — v1 doesn't ask for it; restore already branches.
+- Real Synapse integration — out of scope; we target a documented interface + a local mock.
+- Changing the science, the agent tree, or the sub-agents' internal behaviour.
+
+## Background — what already works (verified this session)
+
+- Checkpoint = zip bundle (`manifest.json` + `blobs/sha256-*`), stored by `LocalZipStore`
+  under `checkpoints_data/<run_id>/` on the MAS side.
+- Manifest already carries `checkpoint_id`, `run_id`, `created_at`, `label`, `resume_from`,
+  session blobs, module stores, and reproducibility pins; secrets are redacted.
+- `run_id = f"{session.app_name}__{session.id}"` (`capture.py:209`) — **self-generated**.
+- REST API (`checkpoints/api.py`): `GET list`, `GET /{id}`, `GET /{id}/bundle`,
+  `POST /{id}/restore`. No outbound notification anywhere.
+- Restore creates a new run (new `contextId`), rehydrates from the bundle, continues over
+  plain A2A. Process-wide busy gate returns `409` during an active invocation.
+- In `run_all` each of the 7 A2A servers checkpoints its own session into the shared dir →
+  multiple `run_id`s (`orchestrator__`, `research__`, `hypotheses__`, `coder__`).
+
+## Architecture
+
+New, small, and reuses the working checkpoint/restore code.
+
+### Components
+
+- **`CoScientist/checkpoints/synapse.py`** — the v1 bridge (the only substantial new module):
+  - reads platform `run_id` + `traceparent` from the incoming A2A `message.metadata`;
+  - stashes them in session state (`synapse:run_id`, `synapse:traceparent`);
+  - after a checkpoint is saved, fires the best-effort "snapshot ready" callback;
+  - builds the `snapshot_ref`.
+- **`scripts/mock_synapse.py`** — the platform stand-in (test/dev harness):
+  - issues a `run_id` + a root `traceparent`, sends the task to the adapter via A2A
+    `message/send` with those in `metadata`;
+  - exposes `POST /points` to receive "snapshot ready" callbacks and record points;
+  - triggers restore: picks a recorded point, issues a **new** `run_id`, calls the
+    adapter's restore with the `point_id`, then continues;
+  - collects OTLP spans to show the stitched trace.
+- **Hooks into existing files** (small diffs):
+  - `plugin.py` — after `store.save(...)`, call the synapse callback;
+  - `capture.py` — take `run_id` from `state["synapse:run_id"]` when present (fallback = current);
+  - `api.py` — the platform-facing checkpoint list is filtered to the current orchestrator run;
+  - `a2a/serve.py` / `a2a/server.py` — read `message.metadata`, set the OTel context from
+    `traceparent`, advertise the checkpoint extension in the Agent Card.
+
+### The 6 changes — concrete
+
+| # | v1 item | Change |
+|---|---|---|
+| endpoint | one MAS → one A2A endpoint, one set of points | Adapter = **orchestrator only** (`a2a serve orchestrator`, remote mode). Its checkpoint API returns only the **current orchestrator run's** points (filter `store.list`). Sub-agent servers still checkpoint internally but are invisible to the platform. |
+| 1 | platform-issued `run_id` (+`traceparent`) | Read from `message.metadata` (`synapse.run_id`, `traceparent`) at entry → session state. `capture.py` stamps `run_id` from there, fallback = `app_name__id`. |
+| 2 | adapter → platform "snapshot ready" | After `store.save`, best-effort `POST {SYNAPSE__CALLBACK_URL}/points` with `{point_id, run_id, time, label, snapshot_ref}`. No separate event. Failures logged, never break the run. |
+| 3 | stable `snapshot_ref` | `snapshot_ref` = URL of the existing `GET /api/checkpoints/{id}/bundle` (snapshot stays with us; platform keeps the link). Added to the callback and the manifest. |
+| 4 | platform-initiated restore | Reuse `POST /restore`; the **mock platform** is the caller. The restored run takes the platform's **new** `run_id` (ties to #1). Busy gate (409) already enforces "prior instance stopped". |
+| 5 | OTel minimal | At entry, build an OTel context from `traceparent` so ADK spans (`invoke_agent`/`execute_tool`/`chat` + attrs: agent/tool/model, status, `run_id`) hang under the platform trace; export OTLP to the mock's collector. |
+
+### Data flow (end-to-end through the mock)
+
+```
+mock: issue run-1a2b + traceparent → A2A message/send (metadata) → adapter (orchestrator)
+adapter: run_id/traceparent into state; ADK spans hang under the platform trace
+module boundary: store.save(bundle) → POST /points {point_id, snapshot_ref=…/bundle} → mock records point
+mock: "continue from point_id" → issues a new run_id → POST /restore → adapter rehydrates from bundle → new run
+```
+
+### Interfaces
+
+- **Incoming A2A `message.metadata`:** `synapse.run_id: str`, `traceparent: str` (W3C).
+- **Callback body (`POST {SYNAPSE__CALLBACK_URL}/points`):**
+  `{ point_id, run_id, time (ISO-8601), label, snapshot_ref (URL) }`.
+- **`snapshot_ref`:** `http://<adapter-host>:<port>/api/checkpoints/{checkpoint_id}/bundle`.
+- **Config (settings, `SYNAPSE__*`):** `enabled: bool`, `callback_url: str|None`,
+  `bundle_base_url: str|None` (host:port used to build `snapshot_ref`),
+  `otlp_endpoint: str|None`. All default off / None → v1 bridge is a no-op, existing
+  behaviour unchanged.
+
+### Testing
+
+- New e2e (patterned on `tests/e2e_checkpoint_a2a.py`) driven **through the mock**, using the
+  scripted deterministic agent (no LLM): assert
+  (a) point `run_id` == the platform-issued id;
+  (b) the "snapshot ready" callback arrived with a resolvable `snapshot_ref`;
+  (c) restore-by-`point_id` reconstitutes state and the new run continues;
+  (d) the exported trace has one platform root with our steps as children.
+- `tests/e2e_checkpoint_a2a.py` (bare restore) stays green — the bridge is off by default.
+- Unit tests for `synapse.py`: metadata parsing, callback body shape, `snapshot_ref` build,
+  `run_id` precedence (platform value wins, fallback otherwise).
+
+## File layout / branch
+
+- Branch: `feat/synapse-v1-adapter` (off `feat/checkpoints`).
+- New: `CoScientist/checkpoints/synapse.py`, `scripts/mock_synapse.py`,
+  `tests/e2e_synapse_v1.py`, this spec.
+- Edited: `checkpoints/plugin.py`, `checkpoints/capture.py`, `checkpoints/api.py`,
+  `a2a/serve.py`, `a2a/server.py`, `config/settings.py` (+`SynapseSettings`).
+
+## Risks / open questions
+
+- **Metadata plumbing depth:** confirm ADK's A2A path surfaces `message.metadata` to a
+  callback/entry hook; if not, fall back to a light `/runs` service call for run_id/traceparent.
+- **OTLP export in `run_all`:** the adapter (orchestrator) is the trace parent; sub-agent
+  servers' spans need the same trace context propagated over A2A — for v1-minimal it is enough
+  to show the orchestrator subtree stitched under the platform root.
+- **Single-endpoint filtering:** "current orchestrator run" must be well-defined when several
+  restores coexist; filter by the active/most-recent orchestrator `run_id`, not all of them.
+- **Adjacent (not in scope but noted):** v1 §4 requires `input-required` to reach the external
+  endpoint; in A2A mode the HITL handler is not swapped today — a separate known gap.

--- a/scripts/mock_synapse.py
+++ b/scripts/mock_synapse.py
@@ -1,0 +1,46 @@
+"""Local stand-in for the Synapse platform — exercises the v1 adapter contract.
+
+Receives "snapshot ready" callbacks (POST /points), and provides helpers to
+issue a platform run_id + W3C traceparent. Real Synapse replaces this later.
+
+Run standalone:  python scripts/mock_synapse.py --port 9100
+"""
+from __future__ import annotations
+
+import argparse
+import secrets
+
+from fastapi import FastAPI, Request
+
+_POINTS: list[dict] = []
+
+app = FastAPI()
+
+
+@app.post("/points")
+async def receive_point(request: Request):
+    _POINTS.append(await request.json())
+    return {"ok": True}
+
+
+@app.get("/points")
+async def list_points():
+    return {"points": _POINTS}
+
+
+def issue_run() -> tuple[str, str]:
+    """Return (run_id, traceparent) with a fresh W3C traceparent."""
+    run_id = f"run-{secrets.token_hex(3)}"
+    trace_id = secrets.token_hex(16)
+    span_id = secrets.token_hex(8)
+    traceparent = f"00-{trace_id}-{span_id}-01"
+    return run_id, traceparent
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=9100)
+    args = p.parse_args()
+    uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="warning")

--- a/tests/e2e_synapse_v1.py
+++ b/tests/e2e_synapse_v1.py
@@ -1,0 +1,210 @@
+"""E2E: the Synapse v1 adapter contract, end-to-end against the local mock.
+
+Scenario (run: ``python tests/e2e_synapse_v1.py``):
+
+1. start the mock Synapse platform in-process (callback receiver);
+2. start an A2A adapter server (subprocess) wrapping a SCRIPTED agent — no LLM,
+   deterministic — with CHECKPOINTS__ENABLED + SYNAPSE__ENABLED;
+3. the mock issues a platform run_id + traceparent and registers them for a
+   contextId via ``POST /api/checkpoints/runs``;
+4. send message #1 over A2A with that contextId → the agent commits
+   ``search_results`` (T1 fires); the adapter stamps the PLATFORM run_id on the
+   point and POSTs "snapshot ready" to the mock;
+5. assert: the mock received a point whose run_id == the issued run_id and whose
+   snapshot_ref resolves via ``GET …/bundle``; the adapter lists only this run's
+   points; a platform-driven ``POST …/restore`` returns a fresh contextId.
+
+The scripted agent lives in this file; ``--serve`` runs the server role.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+PORT = int(os.getenv("E2E_SYNAPSE_PORT", "8138"))
+MOCK_PORT = int(os.getenv("E2E_SYNAPSE_MOCK_PORT", "9138"))
+BASE = f"http://127.0.0.1:{PORT}"
+APP_NAME = "orchestrator"
+
+
+# ─────────────────────────── server role ────────────────────────────────────
+
+def serve() -> None:
+    from google.adk.agents.base_agent import BaseAgent
+    from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.events.event import Event
+    from google.adk.events.event_actions import EventActions
+    from google.genai import types
+
+    class ScriptedOrchestrator(BaseAgent):
+        async def _run_async_impl(self, ctx: InvocationContext):
+            yield Event(
+                author=self.name, invocation_id=ctx.invocation_id,
+                content=types.Content(role="model",
+                                      parts=[types.Part(text="literature review done")]),
+                actions=EventActions(state_delta={"search_results": "GSK3B: 42 candidate molecules"}),
+            )
+            yield Event(
+                author=self.name, invocation_id=ctx.invocation_id,
+                content=types.Content(role="model", parts=[types.Part(text="phase 1 complete")]),
+            )
+
+    import uvicorn
+    from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+
+    from CoScientist.a2a.server import make_a2a_app
+
+    card = AgentCard(
+        name="ScriptedOrchestrator", description="e2e synapse test agent",
+        url=f"{BASE}/", version="1.0.0",
+        capabilities=AgentCapabilities(streaming=True),
+        defaultInputModes=["text/plain"], defaultOutputModes=["text/plain"],
+        skills=[AgentSkill(id="e2e", name="e2e", description="scripted run", tags=["test"])],
+    )
+    app = make_a2a_app(ScriptedOrchestrator(name="ScriptedOrchestrator"), card, APP_NAME)
+    uvicorn.run(app, host="127.0.0.1", port=PORT, log_level="warning")
+
+
+# ─────────────────────────── client helpers ─────────────────────────────────
+
+def _http(method: str, url: str, body: dict | None = None, timeout: float = 60.0) -> dict:
+    import urllib.request
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def a2a_send(text: str, context_id: str) -> dict:
+    message = {"kind": "message", "role": "user", "messageId": uuid.uuid4().hex,
+               "contextId": context_id, "parts": [{"kind": "text", "text": text}]}
+    payload = {"jsonrpc": "2.0", "id": uuid.uuid4().hex,
+               "method": "message/send", "params": {"message": message}}
+    out = _http("POST", f"{BASE}/", payload, timeout=120.0)
+    if "error" in out:
+        raise AssertionError(f"A2A error: {out['error']}")
+    return out["result"]
+
+
+def wait_ready(url: str, proc: subprocess.Popen | None = None, timeout: float = 90.0) -> None:
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            raise AssertionError(f"server died on startup (exit {proc.returncode})")
+        try:
+            import urllib.request
+            urllib.request.urlopen(url, timeout=3.0)
+            return
+        except Exception as exc:  # noqa: BLE001
+            last = exc
+            time.sleep(1.0)
+    raise AssertionError(f"not ready in {timeout}s: {last}")
+
+
+def spawn_server(ckpt_dir: str) -> subprocess.Popen:
+    env = {**os.environ,
+           "CHECKPOINTS__ENABLED": "1", "CHECKPOINTS__DIR": ckpt_dir,
+           "SYNAPSE__ENABLED": "1",
+           "SYNAPSE__CALLBACK_URL": f"http://127.0.0.1:{MOCK_PORT}",
+           "SYNAPSE__BUNDLE_BASE_URL": BASE,
+           "A2A_DISABLE_OPIK": "1", "LOG_AGENT_EVENTS": "0"}
+    return subprocess.Popen([sys.executable, str(Path(__file__).resolve()), "--serve"],
+                            cwd=REPO_ROOT, env=env,
+                            stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
+
+def kill(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill(); proc.wait(timeout=15)
+
+
+# ─────────────────────────── orchestration ──────────────────────────────────
+
+def main() -> None:
+    import uvicorn
+    from scripts.mock_synapse import app as mock_app, issue_run
+
+    threading.Thread(
+        target=lambda: uvicorn.run(mock_app, host="127.0.0.1", port=MOCK_PORT,
+                                   log_level="warning"),
+        daemon=True).start()
+    wait_ready(f"http://127.0.0.1:{MOCK_PORT}/points")
+
+    checks: list[str] = []
+
+    def ok(name: str, cond: bool, detail: str = "") -> None:
+        checks.append(f"[{'PASS' if cond else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+        print(checks[-1])
+        if not cond:
+            raise AssertionError(name)
+
+    ckpt_dir = tempfile.mkdtemp(prefix="synapse_e2e_")
+    print(f"[e2e] checkpoint dir: {ckpt_dir}")
+    server = spawn_server(ckpt_dir)
+    try:
+        wait_ready(f"{BASE}/.well-known/agent-card.json", server)
+        run_id, traceparent = issue_run()
+        ctx = "syn-ctx-1"
+        print(f"[e2e] platform issued run_id={run_id}")
+
+        _http("POST", f"{BASE}/api/checkpoints/runs",
+              {"context_id": ctx, "run_id": run_id, "traceparent": traceparent})
+        a2a_send("start the literature phase for GSK3B", context_id=ctx)
+
+        points = _http("GET", f"http://127.0.0.1:{MOCK_PORT}/points")["points"]
+        ok("platform received a snapshot-ready callback", len(points) >= 1,
+           f"{len(points)} points")
+        ok("point carries the PLATFORM run_id",
+           all(p["run_id"] == run_id for p in points),
+           f"{[p['run_id'] for p in points]} vs {run_id}")
+        ref = points[0]["snapshot_ref"]
+        ok("snapshot_ref points at the adapter bundle URL",
+           bool(ref) and ref.startswith(f"{BASE}/api/checkpoints/") and ref.endswith("/bundle"),
+           str(ref))
+        # the ref actually resolves to a downloadable bundle
+        import urllib.request
+        with urllib.request.urlopen(ref, timeout=10) as r:
+            ok("snapshot_ref resolves (bundle downloadable)", r.status == 200)
+
+        listing = _http("GET", f"{BASE}/api/checkpoints?run_id={run_id}")["checkpoints"]
+        ok("adapter lists only this run's points (single endpoint)",
+           bool(listing) and all(c["run_id"] == run_id for c in listing),
+           f"{[c['run_id'] for c in listing]}")
+
+        pid = next(p["point_id"] for p in points
+                   if p["label"] == "T1_after_literature_review")
+        restored = _http("POST", f"{BASE}/api/checkpoints/{pid}/restore", {})
+        ok("platform-driven restore returns a new contextId",
+           bool(restored.get("context_id")), str(restored.get("context_id")))
+    finally:
+        kill(server)
+
+    print("\n[e2e] ALL SYNAPSE CHECKS PASSED")
+    for line in checks:
+        print("  " + line)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true", help="run the A2A server role")
+    args = parser.parse_args()
+    if args.serve:
+        serve()
+    else:
+        main()

--- a/tests/test_synapse_bridge.py
+++ b/tests/test_synapse_bridge.py
@@ -81,3 +81,47 @@ def test_capture_falls_back_to_run_key(monkeypatch):
     m = asyncio.run(capture.capture_checkpoint(
         session=_FakeSession("ctx-none"), label="T5_invocation_end", store=store))
     assert m.run_id == "orchestrator__ctx-none"
+
+
+# ── Task 4: outbound snapshot-ready callback ─────────────────────────────────
+
+def test_notify_posts_point(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    from CoScientist.checkpoints.model import CheckpointManifest, SessionRef
+    captured = {}
+
+    def fake_post(url, json, timeout):
+        captured["url"] = url
+        captured["body"] = json
+        class R:
+            status_code = 200
+        return R()
+
+    monkeypatch.setattr(synapse, "_synapse_cfg",
+                        lambda: SimpleNamespace(enabled=True, callback_url="http://plat:9000"))
+    monkeypatch.setattr(synapse.httpx, "post", fake_post)
+    m = CheckpointManifest(
+        checkpoint_id="ckpt_X", label="T1_after_literature_review", run_id="run-1",
+        created_at="t", session=SessionRef(app_name="a", user_id="u", session_id="s"),
+        snapshot_ref="http://host/api/checkpoints/ckpt_X/bundle")
+    synapse.notify_snapshot_saved(m)
+    assert captured["url"] == "http://plat:9000/points"
+    assert captured["body"]["point_id"] == "ckpt_X"
+    assert captured["body"]["run_id"] == "run-1"
+    assert captured["body"]["label"] == "T1_after_literature_review"
+    assert captured["body"]["snapshot_ref"] == "http://host/api/checkpoints/ckpt_X/bundle"
+
+
+def test_notify_noop_when_disabled(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    from CoScientist.checkpoints.model import CheckpointManifest, SessionRef
+    monkeypatch.setattr(synapse, "_synapse_cfg",
+                        lambda: SimpleNamespace(enabled=False, callback_url=None))
+    called = {"n": 0}
+    monkeypatch.setattr(synapse.httpx, "post",
+                        lambda *a, **k: called.__setitem__("n", called["n"] + 1))
+    m = CheckpointManifest(
+        checkpoint_id="c", label="L", run_id="r", created_at="t",
+        session=SessionRef(app_name="a", user_id="u", session_id="s"))
+    synapse.notify_snapshot_saved(m)
+    assert called["n"] == 0

--- a/tests/test_synapse_bridge.py
+++ b/tests/test_synapse_bridge.py
@@ -1,0 +1,25 @@
+"""Unit tests for the Synapse v1 adapter bridge (CoScientist/checkpoints/synapse.py)."""
+import asyncio
+import tempfile
+from types import SimpleNamespace
+
+
+# ── Task 1: SynapseSettings ──────────────────────────────────────────────────
+
+def test_synapse_settings_default_off(monkeypatch):
+    monkeypatch.delenv("SYNAPSE__ENABLED", raising=False)
+    from CoScientist.config.settings import Settings
+    s = Settings()
+    assert s.synapse.enabled is False
+    assert s.synapse.callback_url is None
+    assert s.synapse.bundle_base_url is None
+    assert s.synapse.otlp_endpoint is None
+
+
+def test_synapse_settings_from_env(monkeypatch):
+    monkeypatch.setenv("SYNAPSE__ENABLED", "true")
+    monkeypatch.setenv("SYNAPSE__CALLBACK_URL", "http://localhost:9999")
+    from CoScientist.config.settings import Settings
+    s = Settings()
+    assert s.synapse.enabled is True
+    assert s.synapse.callback_url == "http://localhost:9999"

--- a/tests/test_synapse_bridge.py
+++ b/tests/test_synapse_bridge.py
@@ -146,3 +146,32 @@ def test_runs_endpoint_registers():
     assert r.status_code == 200 and r.json()["ok"] is True
     assert synapse.run_id_for("ctx-77") == "run-77"
     assert synapse.traceparent_for("ctx-77") == "00-t-s-01"
+
+
+# ── Task 6: minimal OTel traceparent stitching ───────────────────────────────
+
+def test_otel_span_parents_on_traceparent():
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    from CoScientist.checkpoints import synapse
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    synapse._TRACER = provider.get_tracer("test")   # test-local tracer
+
+    synapse.clear_runs()
+    tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+    synapse.register_run("ctx-tr", "run-tr", tp)
+    h = synapse._start_run_span("ctx-tr", "ScriptedOrchestrator", "run-tr")
+    synapse._end_run_span(h)
+
+    spans = exporter.get_finished_spans()
+    assert any(s.name == "invoke_agent" for s in spans)
+    inv = next(s for s in spans if s.name == "invoke_agent")
+    assert format(inv.context.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+    assert inv.attributes["gen_ai.operation.name"] == "invoke_agent"
+    assert inv.attributes["gen_ai.agent.name"] == "ScriptedOrchestrator"
+    assert inv.attributes["run_id"] == "run-tr"

--- a/tests/test_synapse_bridge.py
+++ b/tests/test_synapse_bridge.py
@@ -125,3 +125,24 @@ def test_notify_noop_when_disabled(monkeypatch):
         session=SessionRef(app_name="a", user_id="u", session_id="s"))
     synapse.notify_snapshot_saved(m)
     assert called["n"] == 0
+
+
+# ── Task 5: POST /api/checkpoints/runs ───────────────────────────────────────
+
+def test_runs_endpoint_registers():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from CoScientist.checkpoints.api import make_checkpoint_router
+    from CoScientist.checkpoints import synapse
+    from CoScientist.checkpoints.store import LocalZipStore
+    synapse.clear_runs()
+    app = FastAPI()
+    app.include_router(make_checkpoint_router(
+        session_service=object(), app_name="orchestrator",
+        store=LocalZipStore(tempfile.mkdtemp())))
+    c = TestClient(app)
+    r = c.post("/api/checkpoints/runs",
+               json={"context_id": "ctx-77", "run_id": "run-77", "traceparent": "00-t-s-01"})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert synapse.run_id_for("ctx-77") == "run-77"
+    assert synapse.traceparent_for("ctx-77") == "00-t-s-01"

--- a/tests/test_synapse_bridge.py
+++ b/tests/test_synapse_bridge.py
@@ -46,3 +46,38 @@ def test_snapshot_ref_none_when_unconfigured(monkeypatch):
     from CoScientist.checkpoints import synapse
     monkeypatch.setattr(synapse, "_bundle_base_url", lambda: None)
     assert synapse.snapshot_ref_for("ckpt_X") is None
+
+
+# ── Task 3: platform run_id + snapshot_ref on the manifest ────────────────────
+
+class _FakeSession:
+    def __init__(self, sid):
+        self.app_name = "orchestrator"
+        self.user_id = "u"
+        self.id = sid
+        self.events = []
+        self.state = {}
+
+
+def test_capture_uses_platform_run_id(monkeypatch):
+    from CoScientist.checkpoints import synapse, capture
+    from CoScientist.checkpoints.store import LocalZipStore
+    synapse.clear_runs()
+    synapse.register_run("ctx-9", "run-PLATFORM", None)
+    monkeypatch.setattr(synapse, "_bundle_base_url", lambda: "http://host:8100")
+    store = LocalZipStore(tempfile.mkdtemp())
+    m = asyncio.run(capture.capture_checkpoint(
+        session=_FakeSession("ctx-9"), label="T1_after_literature_review", store=store))
+    assert m is not None
+    assert m.run_id == "run-PLATFORM"
+    assert m.snapshot_ref == f"http://host:8100/api/checkpoints/{m.checkpoint_id}/bundle"
+
+
+def test_capture_falls_back_to_run_key(monkeypatch):
+    from CoScientist.checkpoints import synapse, capture
+    from CoScientist.checkpoints.store import LocalZipStore
+    synapse.clear_runs()  # nothing registered
+    store = LocalZipStore(tempfile.mkdtemp())
+    m = asyncio.run(capture.capture_checkpoint(
+        session=_FakeSession("ctx-none"), label="T5_invocation_end", store=store))
+    assert m.run_id == "orchestrator__ctx-none"

--- a/tests/test_synapse_bridge.py
+++ b/tests/test_synapse_bridge.py
@@ -23,3 +23,26 @@ def test_synapse_settings_from_env(monkeypatch):
     s = Settings()
     assert s.synapse.enabled is True
     assert s.synapse.callback_url == "http://localhost:9999"
+
+
+# ── Task 2: run registry + snapshot_ref ──────────────────────────────────────
+
+def test_run_registry_roundtrip():
+    from CoScientist.checkpoints import synapse
+    synapse.clear_runs()
+    synapse.register_run("ctx-1", "run-1a2b", "00-abc-def-01")
+    assert synapse.run_id_for("ctx-1") == "run-1a2b"
+    assert synapse.traceparent_for("ctx-1") == "00-abc-def-01"
+    assert synapse.run_id_for("unknown") is None
+
+
+def test_snapshot_ref_build(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    monkeypatch.setattr(synapse, "_bundle_base_url", lambda: "http://host:8100")
+    assert synapse.snapshot_ref_for("ckpt_X") == "http://host:8100/api/checkpoints/ckpt_X/bundle"
+
+
+def test_snapshot_ref_none_when_unconfigured(monkeypatch):
+    from CoScientist.checkpoints import synapse
+    monkeypatch.setattr(synapse, "_bundle_base_url", lambda: None)
+    assert synapse.snapshot_ref_for("ckpt_X") is None


### PR DESCRIPTION
Makes the existing checkpoint subsystem speak the **Synapse platform v1 core contract**, verified end-to-end against a local mock platform. Everything is **off by default** (`SYNAPSE__ENABLED=false`) — behaviour is byte-identical to `feat/checkpoints` until enabled.

Design & plan live in the branch: `docs/superpowers/specs/2026-07-27-synapse-v1-adapter-design.md`, `docs/superpowers/plans/2026-07-29-synapse-v1-adapter.md`.

## What it adds (the v1 core, 6 items)
- **Single adapter endpoint** — the platform talks to one A2A endpoint (orchestrator); `GET /api/checkpoints?run_id=…` returns only that run's points.
- **(1) Platform-issued run_id** — `POST /api/checkpoints/runs` registers `{context_id, run_id, traceparent}`; capture stamps the platform run_id (fallback = existing `app_name__id`).
- **(2) Snapshot-ready callback** — after a snapshot saves, a best-effort `POST {SYNAPSE__CALLBACK_URL}/points` reports the point (no separate event).
- **(3) Stable snapshot_ref** — the existing `GET …/{id}/bundle` URL; the snapshot stays with the MAS, the platform holds only the link.
- **(4) Platform-initiated restore** — reuses `POST …/{id}/restore`, driven by the platform; new run per restore (busy-gate already enforces "prior instance stopped").
- **(5) Minimal OTel** — accepts the incoming `traceparent` and hangs an `invoke_agent` span (with `gen_ai.*` attrs + run_id) under the platform's trace; OTLP export.

## New / changed
- New: `CoScientist/checkpoints/synapse.py` (bridge), `scripts/mock_synapse.py` (mock platform), `tests/test_synapse_bridge.py`, `tests/e2e_synapse_v1.py`.
- Changed (small, gated): `checkpoints/model.py` (`snapshot_ref`), `checkpoints/capture.py` (run_id + ref + notify), `checkpoints/api.py` (`/runs`), `a2a/server.py` (trace plugin), `config/settings.py` (`SynapseSettings`).

## Testing
- 11 unit tests (`tests/test_synapse_bridge.py`) — all pass.
- `tests/e2e_synapse_v1.py` (scripted agent, no LLM) through the mock — ALL CHECKS PASS: platform run_id on points, callback received, snapshot_ref resolves, single-endpoint list, platform-driven restore.
- `tests/e2e_checkpoint_a2a.py` (bare restore) — still green, no regression.
- Full `tests/unit`: 106 passed; the only 2 failures are the pre-existing, documented `test_mcp_patches` ones (locked `mcp` version) — untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
