### PR TITLE
CI: deploy the web UI to a self-hosted runner

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,68 @@
+name: Deploy web UI
+
+# Manual run, or automatic on push to the deploy branch.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: [self-hosted]
+    env:
+      DEPLOY_BRANCH: main
+      SERVICE: coscientist-web
+      HEALTH_URL: http://127.0.0.1:7000/
+    steps:
+      - name: Set up environment
+        # A job-level env: block cannot expand $HOME or run id(1), so resolve the
+        # deploy path, put uv on PATH, and set the user-bus vars here. These land
+        # in the environment of every later step.
+        run: |
+          set -euo pipefail
+          {
+            echo "DEPLOY_DIR=$HOME/cosci/CoScientist"
+            echo "XDG_RUNTIME_DIR=/run/user/$(id -u)"
+            echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus"
+          } >> "$GITHUB_ENV"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Update code in the deploy dir
+        run: |
+          set -euo pipefail
+          cd "$DEPLOY_DIR"
+          git fetch --prune origin
+          git checkout "$DEPLOY_BRANCH"
+          git reset --hard "origin/$DEPLOY_BRANCH"
+          git rev-parse --short HEAD
+
+      - name: Sync dependencies (locked)
+        run: |
+          set -euo pipefail
+          cd "$DEPLOY_DIR"
+          uv sync --frozen
+
+      - name: Link the server secrets
+        run: ln -sfn "$HOME/.config/coscientist/.env" "$DEPLOY_DIR/.env"
+
+      - name: Restart the service
+        run: systemctl --user restart "$SERVICE"
+
+      - name: Health check
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS "$HEALTH_URL" >/dev/null; then
+              echo "healthy after ${i} tries"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "service did not answer on $HEALTH_URL"
+          systemctl --user status "$SERVICE" --no-pager || true
+          journalctl --user -u "$SERVICE" -n 80 --no-pager || true
+          exit 1

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,171 @@
+# Deploy the CoScientist web UI
+
+The web UI is a long-running uvicorn server. A GitHub Actions job is short. So
+the job does not host the server. A user-level `systemd` service owns the
+process. The job updates the code and restarts the service.
+
+Parts:
+
+- `coscientist-web.service` — the systemd user unit that runs the server.
+- `../.github/workflows/deploy-web.yml` — the deploy job for the self-hosted
+  runner.
+
+## One-time setup on the server
+
+Run these steps once, as the same Linux user that runs the GitHub Actions
+runner. The steps need no root.
+
+1. Install `uv` for this user.
+
+   ```
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+   This puts `uv` at `~/.local/bin/uv`. Confirm with `~/.local/bin/uv --version`.
+
+2. Clone the repository to the fixed deploy directory. The runner work
+   directory changes each job, so the service uses a stable path instead. If
+   the clone already exists, skip this step.
+
+   ```
+   git clone https://github.com/aimclub/CoScientist.git ~/cosci/CoScientist
+   cd ~/cosci/CoScientist
+   git checkout main
+   ```
+
+   The deploy job, the systemd unit, and these steps all use the same fixed
+   path `$HOME/cosci/CoScientist`. Keep them the same. To move it, change
+   `DEPLOY_DIR` in `deploy-web.yml` and `WorkingDirectory` in
+   `coscientist-web.service` together.
+
+3. Put the secrets file at a protected path outside the repository.
+
+   ```
+   mkdir -p ~/.config/coscientist
+   cp /path/to/your/.env ~/.config/coscientist/.env
+   chmod 600 ~/.config/coscientist/.env
+   ```
+
+   Keep secrets out of git. Do not commit this file. See "The .env file" below.
+
+4. Install and start the service.
+
+   ```
+   mkdir -p ~/.config/systemd/user
+   cp ~/cosci/CoScientist/deploy/coscientist-web.service ~/.config/systemd/user/
+   ln -sfn ~/.config/coscientist/.env ~/cosci/CoScientist/.env
+   systemctl --user daemon-reload
+   systemctl --user enable --now coscientist-web
+   ```
+
+5. Keep the service alive after logout and after a reboot.
+
+   ```
+   loginctl enable-linger "$USER"
+   ```
+
+6. Check the state.
+
+   ```
+   systemctl --user status coscientist-web --no-pager
+   curl -fsS http://127.0.0.1:7000/ >/dev/null && echo up
+   ```
+
+Open the firewall for the port if clients are not on the server. The service
+binds `0.0.0.0:7000`.
+
+## The deploy job
+
+The job runs on the self-hosted runner. On each run it:
+
+1. Resets the deploy directory to the pushed commit (`git reset --hard`).
+2. Runs `uv sync --frozen` to match `uv.lock`.
+3. Re-links `.env` into the deploy directory.
+4. Restarts the user service.
+5. Polls `http://127.0.0.1:7000/` until it answers, or fails the job.
+
+Triggers: a push to `main`, or a manual run from the Actions tab. To deploy a
+different branch, change `DEPLOY_BRANCH` in `deploy-web.yml`.
+
+## The .env file
+
+The application reads configuration from a `.env` file in its working
+directory. `.env` is gitignored, so it never enters the repository or the
+workflow. The service reads it through the symlink at
+`~/cosci/CoScientist/.env`.
+
+Split of duties:
+
+- Secrets and endpoints stay in `~/.config/coscientist/.env` (LLM keys, S3,
+  Postgres, service URLs).
+- Runtime toggles stay in the unit file as `Environment=` lines
+  (`HITL__ENABLED=true`, `CONTEXT_INIT__ENABLED=true`). `load_dotenv` does not
+  override real environment variables, so the unit wins over the same keys in
+  `.env`.
+
+Two notes on the `.env` content:
+
+1. The frame form needs `HITL__ENABLED=true`. The unit sets it. Do not set it
+   to `false` in `.env` and expect the form.
+2. Remove any line that is not `KEY=VALUE`. A bare path line such as
+   `/root/.opik.config` is not a valid variable and only adds noise.
+
+## Config keys the web UI needs
+
+The server starts without a database, but the agents need live model access.
+At minimum set these in `~/.config/coscientist/.env`:
+
+- `LLM__OPENAI_API_KEY`, `LLM__MAIN_MODEL`, `LLM__MAIN_URL`.
+- `LLM__ALLOWED_PROVIDERS` for the providers you use.
+- `SERVICES__TAVILY_API_KEY` and `SERVICES__OPENALEX_API_KEY` for web and
+  literature search.
+
+Keys use the nested form `SECTION__FIELD` (double underscore).
+
+## OpenRouter proxy
+
+The VM egress blocks `openrouter.ai`. The institution runs a tunnel on the
+docker0 bridge to reach it. The systemd unit sets these variables, so the
+service uses the tunnel with no code change:
+
+```
+Environment=HTTP_PROXY=http://172.17.0.1:7890
+Environment=HTTPS_PROXY=http://172.17.0.1:7890
+Environment=NO_PROXY=localhost,127.0.0.1
+```
+
+Facts to know:
+
+- The tunnel carries only `openrouter.ai`. All other hosts go out the normal
+  route, so this global setting does not affect Tavily, OpenAlex, or PubMed.
+- TLS stays end to end. The proxy moves bytes only. The client checks the
+  certificate as usual.
+- The proxy is reachable only from this server. The address `172.17.0.1` does
+  not route from outside.
+- It is fail-closed. If the proxy is down, OpenRouter calls fail. They do not
+  fall back to a direct connection.
+
+Test the tunnel from the VM. A working tunnel answers with country `LV`:
+
+```
+HTTPS_PROXY=http://172.17.0.1:7890 curl -s https://api.myip.com
+```
+
+If the port refuses the connection, the proxy container is down:
+
+```
+docker ps --filter name=openhands-xray-proxy --format '{{.Status}}'
+```
+
+## Common operations
+
+```
+# Watch logs
+journalctl --user -u coscientist-web -f
+
+# Restart by hand
+systemctl --user restart coscientist-web
+
+# Stop
+systemctl --user stop coscientist-web
+```

--- a/deploy/coscientist-web.service
+++ b/deploy/coscientist-web.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=CoScientist web UI (uvicorn)
+
+[Service]
+Type=simple
+WorkingDirectory=%h/cosci/CoScientist
+
+# Runtime toggles live here. Secrets do not.
+# The application reads secrets from the .env symlink in WorkingDirectory
+# (load_dotenv). load_dotenv does not override real environment variables,
+# so these lines win over the same keys in .env.
+Environment=HITL__ENABLED=true
+Environment=CONTEXT_INIT__ENABLED=true
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+# openrouter.ai is blocked on the VM egress. Reach it through the institutional
+# tunnel on the docker0 bridge. The proxy tunnels only openrouter.ai and
+# forwards all other traffic normally, so a global setting is safe. httpx and
+# litellm read these variables on their own. The proxy is reachable only from
+# this server, and it is fail-closed (no direct fallback if it is down).
+Environment=HTTP_PROXY=http://172.17.0.1:7890
+Environment=HTTPS_PROXY=http://172.17.0.1:7890
+Environment=NO_PROXY=localhost,127.0.0.1
+
+# Absolute path to uv avoids a minimal-PATH surprise in the systemd session.
+ExecStart=%h/.local/bin/uv run --frozen python -m CoScientist web --host 0.0.0.0 --port 7000
+
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This PR adds a deploy path for the uvicorn web UI. A GitHub Actions job is short, so the job does not host the server. A user-level systemd service owns the process. The job updates the code and restarts the service.

Files:
- deploy/coscientist-web.service — user-level systemd unit. Restart=always. Runtime toggles are Environment= lines. Secrets come from a .env symlink.
- .github/workflows/deploy-web.yml — self-hosted job: reset the deploy dir to the pushed commit, uv sync --frozen, re-link .env, restart the service, health-check GET /.
- deploy/README.md — one-time server setup, the .env split, and ops commands.